### PR TITLE
feat(export): filter exported splats before they ship

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,13 +29,14 @@ Pipeline orchestrated by Bash scripts (`scripts/`). Configuration in `config/*.s
 - `config/defaults.sh` — base defaults for all model types
 - `webui.py` — Gradio UI wrapping run.sh
 - `docker/run.sh` — Docker wrapper for run.sh
+- `scripts/clean_splat.py` — post-export splat filter (opacity, size, anisotropy, outliers)
 
 Key flows:
 - `video` → extract frames (ffmpeg)
 - `sfm` → structure from motion (COLMAP/GLOMAP/HLoc/VGGSfM)
 - `process` → prepare data for training
 - `train` → neural surface reconstruction (sdfstudio)
-- `export` → extract and texture mesh
+- `export` → extract and texture mesh; splat exports are filtered by `clean_splat.py`
 
 ## Commands
 

--- a/README.md
+++ b/README.md
@@ -308,11 +308,17 @@ a comma-separated value, for example `export --method poisson,orbit-frames`. For
 `orbit-frames` is additive to the normal export.
 
 **Splat cleanup:** every exported splat PLY goes through `scripts/clean_splat.py` before it lands on disk. Only the
-opacity filter runs by default, dropping Gaussians below 0.05, which cuts file size well below what nerfstudio's own
-1/255 export cull leaves and does not change the render on the scenes we measured. Use `export --no-clean` to keep the
-raw output, `--clean-opacity <float>` to move the threshold, and `--clean-max-scale-quantile <q>`,
-`--clean-max-anisotropy <ratio>`, or `--clean-sor` to switch on the size, needle, and outlier filters, none of which
-run unless asked. The script also works on an existing PLY, so you can try settings without re-exporting:
+opacity filter runs by default, dropping Gaussians below 0.05, which takes a 1M-Gaussian MCMC export from 207 MB to
+178 MB and a 100k one from 21.5 MB to 20.4 MB. The threshold comes from pruning checkpoints at several values and
+re-running `ns-eval`: 0.05 moved LPIPS by less than a tenth of the per-image spread on both scenes tried, while 0.1
+cost a full spread on the sharper one.
+
+Use `export --no-clean` to keep the raw output, `--clean-opacity <float>` to move the threshold, and
+`--clean-max-scale-quantile <q>`, `--clean-max-anisotropy <ratio>`, or `--clean-sor` to switch on the size, needle,
+and outlier filters. Those three stay off until someone measures them, and the needle filter in particular is not the
+free win it looks like: an axis ratio of 20 would take 46% of the Gaussians out of that same export, and a thin
+Gaussian is how a splat represents thin structure. The script also works on an existing PLY, so you can try settings
+without re-exporting:
 
 ```bash
 scripts/clean_splat.py splat.ply --dry-run --clean-sor    # report what each stage would remove

--- a/README.md
+++ b/README.md
@@ -308,10 +308,12 @@ a comma-separated value, for example `export --method poisson,orbit-frames`. For
 `orbit-frames` is additive to the normal export.
 
 **Splat cleanup:** every exported splat PLY goes through `scripts/clean_splat.py` before it lands on disk. Only the
-opacity filter runs by default, dropping Gaussians below 0.05, which takes a 1M-Gaussian MCMC export from 207 MB to
-178 MB and a 100k one from 21.5 MB to 20.4 MB. The threshold comes from pruning checkpoints at several values and
-re-running `ns-eval`: 0.05 moved LPIPS by less than a tenth of the per-image spread on both scenes tried, while 0.1
-cost a full spread on the sharper one.
+opacity filter runs by default, dropping Gaussians below 0.05. What that saves depends on the capture rather than on
+the settings: across 15 splatfacto-mcmc exports it removed between 4.9% and 62% of the Gaussians, median 28%. Object
+captures sit at the top of that range because the model fills the empty space around the subject with faint
+Gaussians, and outdoor walkthroughs where every direction has content sit at the bottom. The threshold comes from
+pruning checkpoints at several values and re-running `ns-eval`: 0.05 moved LPIPS by less than a tenth of the
+per-image spread on both scenes tried, while 0.1 cost a full spread on the sharper one.
 
 Use `export --no-clean` to keep the raw output, `--clean-opacity <float>` to move the threshold, and
 `--clean-max-scale-quantile <q>`, `--clean-max-anisotropy <ratio>`, or `--clean-sor` to switch on the size, needle,
@@ -324,6 +326,11 @@ without re-exporting:
 scripts/clean_splat.py splat.ply --dry-run --clean-sor    # report what each stage would remove
 scripts/clean_splat.py splat.ply -o splat_clean.ply --opacity 0.1
 ```
+
+**Shipping to the web:** the container format is a larger lever than anything in this filter. One 250k-Gaussian
+export measures 43 MB as a PLY, 4.2 MB as `.spz`, and 2.0 MB as `.sog`; running the opacity filter first takes the
+SPZ to 1.6 MB. `npx @playcanvas/splat-transform in.ply out.spz` converts between all three. Clean first, convert
+second: the compressed formats quantize what they are given, so a Gaussian removed beforehand costs nothing at all.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -307,6 +307,18 @@ For NeRF/ngp models, request several exporters by repeating `--method` or using
 a comma-separated value, for example `export --method poisson,orbit-frames`. For SDF and splat models,
 `orbit-frames` is additive to the normal export.
 
+**Splat cleanup:** every exported splat PLY goes through `scripts/clean_splat.py` before it lands on disk. Only the
+opacity filter runs by default, dropping Gaussians below 0.05, which cuts file size well below what nerfstudio's own
+1/255 export cull leaves and does not change the render on the scenes we measured. Use `export --no-clean` to keep the
+raw output, `--clean-opacity <float>` to move the threshold, and `--clean-max-scale-quantile <q>`,
+`--clean-max-anisotropy <ratio>`, or `--clean-sor` to switch on the size, needle, and outlier filters, none of which
+run unless asked. The script also works on an existing PLY, so you can try settings without re-exporting:
+
+```bash
+scripts/clean_splat.py splat.ply --dry-run --clean-sor    # report what each stage would remove
+scripts/clean_splat.py splat.ply -o splat_clean.ply --opacity 0.1
+```
+
 </details>
 
 <details markdown="1">

--- a/scripts/clean_splat.py
+++ b/scripts/clean_splat.py
@@ -1,0 +1,318 @@
+#!/usr/bin/env python3
+"""Filter a 3D Gaussian Splatting PLY down to what is worth shipping.
+
+A trained splat carries a large tail of Gaussians that contribute almost nothing
+to a rendered view: near-transparent blobs, a few enormous ones covering half the
+scene, and needle-shaped slivers. They cost file size and viewer performance
+without earning it back in quality.
+
+Only the opacity stage is on by default, because it is the only one whose quality
+cost has been measured (by filtering a checkpoint and re-running ns-eval): at 0.05
+it removes roughly 38% of Gaussians for an LPIPS change well inside the per-image
+spread on both a cluttered outdoor capture and a sharp object capture. 0.10 is
+free on the former and costs a full spread on the latter, so it is not a safe
+default. The scale, anisotropy and outlier stages are implemented but off until
+they have been measured the same way; see hummat/mini-mesh#30.
+
+The output is always binary_little_endian, whatever the input was.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import numpy as np
+
+# PLY scalar names and their numpy equivalents, both the short and long spellings.
+PLY_DTYPES = {
+    "char": "i1",
+    "int8": "i1",
+    "uchar": "u1",
+    "uint8": "u1",
+    "short": "i2",
+    "int16": "i2",
+    "ushort": "u2",
+    "uint16": "u2",
+    "int": "i4",
+    "int32": "i4",
+    "uint": "u4",
+    "uint32": "u4",
+    "float": "f4",
+    "float32": "f4",
+    "double": "f8",
+    "float64": "f8",
+}
+
+SCALE_FIELDS = ("scale_0", "scale_1", "scale_2")
+
+
+class PlyError(RuntimeError):
+    """The file is not a Gaussian splat PLY this script can work with."""
+
+
+def read_ply(path: Path) -> tuple[np.ndarray, list[str]]:
+    """Return the vertex data as a structured array plus the property names."""
+    with path.open("rb") as handle:
+        if handle.readline().strip() != b"ply":
+            raise PlyError(f"{path} does not start with a ply magic line")
+
+        fmt = ""
+        count = -1
+        fields: list[tuple[str, str]] = []
+        in_vertex_element = False
+        while True:
+            raw = handle.readline()
+            if not raw:
+                raise PlyError(f"{path} ended before end_header")
+            parts = raw.decode("ascii", errors="replace").split()
+            if not parts:
+                continue
+            if parts[0] == "format":
+                fmt = parts[1]
+            elif parts[0] == "element":
+                # Only the vertex element carries Gaussians; anything else would
+                # need its own offsets, so refuse rather than silently mangle it.
+                in_vertex_element = parts[1] == "vertex"
+                if in_vertex_element:
+                    count = int(parts[2])
+                elif count >= 0:
+                    raise PlyError(f"{path} has elements after vertex, which is not supported")
+            elif parts[0] == "property" and in_vertex_element:
+                if parts[1] == "list":
+                    raise PlyError(f"{path} has a list property on vertex, which is not supported")
+                if parts[1] not in PLY_DTYPES:
+                    raise PlyError(f"{path} has unknown property type {parts[1]!r}")
+                fields.append((parts[2], PLY_DTYPES[parts[1]]))
+            elif parts[0] == "end_header":
+                break
+
+        if count < 0 or not fields:
+            raise PlyError(f"{path} has no vertex element")
+
+        names = [name for name, _ in fields]
+        if fmt == "binary_little_endian":
+            dtype = np.dtype([(name, "<" + kind) for name, kind in fields])
+            data = np.frombuffer(handle.read(dtype.itemsize * count), dtype=dtype, count=count)
+        elif fmt == "binary_big_endian":
+            dtype = np.dtype([(name, ">" + kind) for name, kind in fields])
+            data = np.frombuffer(handle.read(dtype.itemsize * count), dtype=dtype, count=count)
+        elif fmt == "ascii":
+            dtype = np.dtype([(name, "<" + kind) for name, kind in fields])
+            flat = np.loadtxt(handle, max_rows=count, ndmin=2)
+            data = np.empty(count, dtype=dtype)
+            for i, name in enumerate(names):
+                data[name] = flat[:, i]
+        else:
+            raise PlyError(f"{path} has unsupported format {fmt!r}")
+
+    if len(data) != count:
+        raise PlyError(f"{path} declares {count} vertices but holds {len(data)}")
+    return data, names
+
+
+def write_ply(path: Path, data: np.ndarray, names: list[str]) -> None:
+    """Write a binary little-endian PLY with one vertex element."""
+    out = np.empty(
+        len(data), dtype=np.dtype([(name, "<" + data.dtype[name].str[1:]) for name in names])
+    )
+    for name in names:
+        out[name] = data[name]
+
+    header = ["ply", "format binary_little_endian 1.0", f"element vertex {len(out)}"]
+    reverse = {
+        value: key
+        for key, value in PLY_DTYPES.items()
+        if key in ("uchar", "int", "float", "double")
+    }
+    for name in names:
+        kind = out.dtype[name].str[1:]
+        header.append(f"property {reverse.get(kind, 'float')} {name}")
+    header.append("end_header")
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("wb") as handle:
+        handle.write(("\n".join(header) + "\n").encode("ascii"))
+        handle.write(out.tobytes())
+
+
+def require(names: list[str], needed: tuple[str, ...], stage: str) -> None:
+    missing = [name for name in needed if name not in names]
+    if missing:
+        raise PlyError(f"{stage} needs properties absent from this PLY: {', '.join(missing)}")
+
+
+def opacity_keep(data: np.ndarray, names: list[str], threshold: float) -> np.ndarray:
+    """Keep Gaussians whose opacity is at least the threshold.
+
+    The stored value is a logit, which is what nerfstudio's own export threshold
+    (`opacity < logit(1/255)`) compares against, so it is converted rather than
+    compared raw.
+    """
+    require(names, ("opacity",), "opacity filter")
+    return 1.0 / (1.0 + np.exp(-data["opacity"].astype(np.float64))) >= threshold
+
+
+def extents(data: np.ndarray) -> np.ndarray:
+    """Per-Gaussian scales in world units; the PLY stores their logarithms."""
+    return np.exp(np.stack([data[name].astype(np.float64) for name in SCALE_FIELDS], axis=1))
+
+
+def scale_keep(data: np.ndarray, names: list[str], quantile: float) -> np.ndarray:
+    """Drop the largest Gaussians by longest axis, cut at a quantile of the population.
+
+    An absolute threshold cannot be shared between scenes because scene scale is
+    arbitrary, so the cut is relative to this splat's own distribution.
+    """
+    require(names, SCALE_FIELDS, "scale filter")
+    longest = extents(data).max(axis=1)
+    return longest <= np.quantile(longest, quantile)
+
+
+def anisotropy_keep(data: np.ndarray, names: list[str], ratio: float) -> np.ndarray:
+    """Drop needles: Gaussians whose longest axis exceeds the shortest by `ratio`."""
+    require(names, SCALE_FIELDS, "anisotropy filter")
+    axes = extents(data)
+    shortest = np.maximum(axes.min(axis=1), np.finfo(np.float64).tiny)
+    return axes.max(axis=1) / shortest <= ratio
+
+
+def outlier_keep(
+    data: np.ndarray, names: list[str], neighbours: int, std_ratio: float
+) -> np.ndarray:
+    """Statistical outlier removal over Gaussian centres.
+
+    Drops points whose mean distance to their k nearest neighbours is more than
+    `std_ratio` standard deviations above the population mean, which is the usual
+    way to strip the sparse halo of floaters around a reconstruction.
+    """
+    require(names, ("x", "y", "z"), "outlier filter")
+    try:
+        from scipy.spatial import cKDTree
+    except ModuleNotFoundError as exc:  # optional: the other stages need no scipy
+        raise PlyError("--sor needs scipy; install it or drop the flag") from exc
+
+    points = np.stack([data[axis].astype(np.float64) for axis in ("x", "y", "z")], axis=1)
+    # The first neighbour of a point is itself, so ask for one extra and drop it.
+    distances, _ = cKDTree(points).query(points, k=neighbours + 1, workers=-1)
+    mean_distance = distances[:, 1:].mean(axis=1)
+    return mean_distance <= mean_distance.mean() + std_ratio * mean_distance.std()
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("input", type=Path, help="Gaussian splat PLY to filter")
+    parser.add_argument(
+        "-o", "--output", type=Path, default=None, help="output PLY (default: overwrite input)"
+    )
+    parser.add_argument(
+        "--opacity",
+        type=float,
+        default=0.05,
+        help="drop Gaussians below this opacity, 0 disables the stage (default: 0.05)",
+    )
+    parser.add_argument(
+        "--max-scale-quantile",
+        type=float,
+        default=None,
+        help="drop Gaussians whose longest axis is above this quantile, e.g. 0.999 (default: off)",
+    )
+    parser.add_argument(
+        "--max-anisotropy",
+        type=float,
+        default=None,
+        help="drop Gaussians whose axis ratio exceeds this, e.g. 20 (default: off)",
+    )
+    parser.add_argument(
+        "--sor", action="store_true", help="statistical outlier removal over centres (needs scipy)"
+    )
+    parser.add_argument(
+        "--sor-neighbours", type=int, default=16, help="neighbours for --sor (default: 16)"
+    )
+    parser.add_argument(
+        "--sor-std-ratio", type=float, default=2.0, help="std multiplier for --sor (default: 2.0)"
+    )
+    parser.add_argument(
+        "--dry-run", action="store_true", help="report what would be removed and write nothing"
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    if not 0.0 <= args.opacity < 1.0:
+        print("[ERROR]: --opacity must be in [0, 1)", file=sys.stderr)
+        return 2
+
+    try:
+        data, names = read_ply(args.input)
+    except (PlyError, OSError) as exc:
+        print(f"[ERROR]: {exc}", file=sys.stderr)
+        return 1
+
+    stages: list[tuple[str, np.ndarray]] = []
+    try:
+        if args.opacity > 0.0:
+            stages.append((f"opacity < {args.opacity}", opacity_keep(data, names, args.opacity)))
+        if args.max_scale_quantile is not None:
+            stages.append(
+                (
+                    f"scale > q{args.max_scale_quantile}",
+                    scale_keep(data, names, args.max_scale_quantile),
+                )
+            )
+        if args.max_anisotropy is not None:
+            stages.append(
+                (
+                    f"anisotropy > {args.max_anisotropy}",
+                    anisotropy_keep(data, names, args.max_anisotropy),
+                )
+            )
+        if args.sor:
+            stages.append(
+                (
+                    f"outliers (k={args.sor_neighbours}, {args.sor_std_ratio} sigma)",
+                    outlier_keep(data, names, args.sor_neighbours, args.sor_std_ratio),
+                )
+            )
+    except PlyError as exc:
+        print(f"[ERROR]: {exc}", file=sys.stderr)
+        return 1
+
+    total = len(data)
+    keep = np.ones(total, dtype=bool)
+    for label, stage in stages:
+        # Report each stage against what earlier stages left, so the numbers add up
+        # to the final count instead of double-counting Gaussians two stages agree on.
+        removed = int((keep & ~stage).sum())
+        keep &= stage
+        print(f"[clean]: {label:<40} -{removed:>9,} ({removed / total:6.2%})")
+
+    survivors = int(keep.sum())
+    print(f"[clean]: {'kept':<40}  {survivors:>9,} ({survivors / total:6.2%} of {total:,})")
+    if not stages:
+        print("[clean]: every stage disabled, nothing to do")
+
+    if args.dry_run:
+        print("[clean]: dry run, no file written")
+        return 0
+    if survivors == 0:
+        print(
+            "[ERROR]: every Gaussian was filtered out; refusing to write an empty splat",
+            file=sys.stderr,
+        )
+        return 1
+
+    output = args.output or args.input
+    before = args.input.stat().st_size
+    write_ply(output, data[keep], names)
+    after = output.stat().st_size
+    print(f"[clean]: {before / 1e6:.1f} MB -> {after / 1e6:.1f} MB  ({output})")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/export.sh
+++ b/scripts/export.sh
@@ -45,6 +45,53 @@ experiment_model_name() {
   echo "$name"
 }
 
+nerfstudio_python() {
+  # scripts/env.sh prepends $repo/.venv/bin to PATH whenever that directory exists,
+  # so `python` may be a dev venv interpreter with no torch while the pipeline itself
+  # runs under another one. Probe candidates for torch rather than trusting the name,
+  # and check for the module without importing it so this stays cheap.
+  local probe candidate entry shebang first
+  probe='import importlib.util as u, sys; sys.exit(0 if u.find_spec("torch") else 1)'
+
+  # A console script's shebang names the interpreter it was installed for, which is
+  # the one that owns nerfstudio.
+  entry="$(command -v ns-export 2>/dev/null)" || entry=""
+  shebang=""
+  if [ -n "$entry" ]; then
+    first="$(head -n 1 "$entry" 2>/dev/null)"
+    case "$first" in
+      '#!'*)
+        first="${first#\#!}"
+        shebang="${first%% *}"
+        if [ "$(basename "$shebang")" = env ]; then
+          first="${first#* }"
+          shebang="${first%% *}"
+        fi
+        ;;
+    esac
+  fi
+
+  for candidate in python python3 "$shebang"; do
+    [ -n "$candidate" ] || continue
+    command -v "$candidate" >/dev/null 2>&1 || continue
+    if "$candidate" -c "$probe" >/dev/null 2>&1; then
+      echo "$candidate"
+      return
+    fi
+  done
+
+  # Nothing claims torch: keep the historical call so the failure is the script's own.
+  echo python
+}
+
+clean_splat_output() {
+  local output_path="$1"
+  if [ "$clean_splat" != true ] || [ ! -f "$output_path" ]; then
+    return 0
+  fi
+  run_cmd "$(nerfstudio_python)" "$script_dir/clean_splat.py" "$output_path" "${clean_splat_args[@]}"
+}
+
 nerf_export_output_path() {
   local exp_path="$1"
   local model_name="$2"
@@ -202,6 +249,13 @@ function show_help {
   echo "                              --obb-rotation <float float float>        Rotation of oriented bounding-box (default: 0 0 0)"
   echo "                              --obb-scale <float float float>           Scale of oriented bounding-box (default: 1 1 1)"
   echo "                              --downscale-factor <int>                  Image downscale factor for TSDF extraction (default: 2)"
+  echo "                              --no-clean                                Skip splat cleanup after export"
+  echo "                              --clean-opacity <float>                   Drop Gaussians below this opacity (default: 0.05)"
+  echo "                              --clean-max-scale-quantile <float>        Drop Gaussians above this size quantile (default: off)"
+  echo "                              --clean-max-anisotropy <float>            Drop Gaussians above this axis ratio (default: off)"
+  echo "                              --clean-sor                               Statistical outlier removal on centres (needs scipy)"
+  echo "                              --clean-sor-neighbours <int>              Neighbours per outlier test (default: 16)"
+  echo "                              --clean-sor-std-ratio <float>             Outlier cut in std devs (default: 2.0)"
   echo "                              --mesh-only                               Extract mesh but skip texturing (SDF only)"
   echo "                              --texture-only                            Texture existing mesh, skip extraction (SDF only)"
   echo "                              --input-mesh-filename <path>              Custom mesh file for texturing (requires --texture-only)"
@@ -231,6 +285,8 @@ texture_mesh_args=("${EXPORT_DEFAULTS[@]}")
 nerf_args=()
 nerf_tsdf_args=()
 splatfactow_args=()
+clean_splat_args=()
+clean_splat=true
 nerf_methods=()
 method_requested=false
 orbit_frames_requested=false
@@ -344,6 +400,19 @@ while [ $i -lt ${#export_args[@]} ]; do
       esac
       i=$((i+4))
       ;;
+    --no-clean)
+      clean_splat=false
+      i=$((i+1))
+      ;;
+    --clean-opacity|--clean-max-scale-quantile|--clean-max-anisotropy|--clean-sor-neighbours|--clean-sor-std-ratio)
+      require_args "${export_args[$i]}" 1 "$remaining"
+      clean_splat_args+=("${export_args[$i]/--clean-/--}" "${export_args[$((i+1))]}")
+      i=$((i+2))
+      ;;
+    --clean-sor)
+      clean_splat_args+=("--sor")
+      i=$((i+1))
+      ;;
     --mesh-only)
       mesh_only=true
       i=$((i+1))
@@ -403,7 +472,7 @@ if [ -f "$exp_path/config.yml" ]; then
       nerf_output_path="$(nerf_export_output_path "$exp_path" "$model_name" poisson)"
       if should_run_export "$nerf_output_path"; then
         if [ "$model_name" = splatfacto-w-light ]; then
-          run_cmd python "$script_dir/export_splatfactow.py" \
+          run_cmd "$(nerfstudio_python)" "$script_dir/export_splatfactow.py" \
             --load-config "$exp_path/config.yml" \
             --output-dir "$exp_path" \
             --obb-center "${nerf_obb_center[@]}" \
@@ -420,6 +489,7 @@ if [ -f "$exp_path/config.yml" ]; then
             --obb-scale "${nerf_obb_scale[@]}" \
             "${nerf_args[@]}"
         fi
+        clean_splat_output "$nerf_output_path"
       fi
       if [ "$orbit_frames_requested" = true ]; then
         run_nerfstudio_orbit_frames_export "$exp_path"

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -244,6 +244,9 @@ function show_help {
   echo "                       --mesh-only                                Extract mesh but skip texturing (SDF only)"
   echo "                       --texture-only                             Texture existing mesh, skip extraction (SDF only)"
   echo "                       --input-mesh-filename <path>               Custom mesh file for texturing (requires --texture-only)"
+  echo "                       --no-clean                                 Skip splat cleanup after export"
+  echo "                       --clean-opacity <float>                    Drop Gaussians below this opacity (default: 0.05)"
+  echo "                       --clean-sor                                Statistical outlier removal on splat centres"
   echo "                       --data <path>                              Override data path (for Docker/local portability)"
   echo
   echo "Examples:"

--- a/tests/test_clean_splat.py
+++ b/tests/test_clean_splat.py
@@ -1,0 +1,141 @@
+"""Unit tests for the Gaussian splat cleanup filter."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+
+import numpy as np
+import pytest
+
+FIELDS = ["x", "y", "z", "opacity", "scale_0", "scale_1", "scale_2"]
+
+
+def _load_module() -> ModuleType:
+    repo_root = Path(__file__).resolve().parents[1]
+    module_path = repo_root / "scripts" / "clean_splat.py"
+    spec = importlib.util.spec_from_file_location("clean_splat", module_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+clean_splat = _load_module()
+
+
+def _splat(opacity_logits: np.ndarray, scales: np.ndarray | None = None) -> np.ndarray:
+    count = len(opacity_logits)
+    data = np.zeros(count, dtype=np.dtype([(name, "<f4") for name in FIELDS]))
+    data["opacity"] = opacity_logits
+    if scales is None:
+        scales = np.full((count, 3), -3.0)
+    for i in range(3):
+        data[f"scale_{i}"] = scales[:, i]
+    return data
+
+
+def test_round_trip_preserves_values(tmp_path: Path) -> None:
+    rng = np.random.default_rng(0)
+    data = _splat(rng.normal(size=64).astype(np.float32))
+    data["x"] = rng.normal(size=64)
+    path = tmp_path / "splat.ply"
+
+    clean_splat.write_ply(path, data, FIELDS)
+    restored, names = clean_splat.read_ply(path)
+
+    assert names == FIELDS
+    assert len(restored) == len(data)
+    assert np.allclose(restored["x"], data["x"])
+    assert np.allclose(restored["opacity"], data["opacity"])
+
+
+def test_reads_ascii_ply(tmp_path: Path) -> None:
+    data = _splat(np.array([2.0, -6.0], dtype=np.float32))
+    path = tmp_path / "ascii.ply"
+    header = ["ply", "format ascii 1.0", f"element vertex {len(data)}"]
+    header += [f"property float {name}" for name in FIELDS] + ["end_header"]
+    rows = [" ".join(str(float(row[name])) for name in FIELDS) for row in data]
+    path.write_text("\n".join(header + rows) + "\n")
+
+    restored, names = clean_splat.read_ply(path)
+
+    assert names == FIELDS
+    assert np.allclose(restored["opacity"], data["opacity"], atol=1e-5)
+
+
+def test_opacity_filter_cuts_on_sigmoid_not_logit() -> None:
+    # sigmoid(-4) is about 0.018, sigmoid(0) is 0.5: a raw comparison would keep both.
+    data = _splat(np.array([-4.0, 0.0], dtype=np.float32))
+
+    keep = clean_splat.opacity_keep(data, FIELDS, 0.05)
+
+    assert keep.tolist() == [False, True]
+
+
+def test_anisotropy_filter_drops_needles() -> None:
+    scales = np.log(np.array([[1.0, 1.0, 1.0], [100.0, 1.0, 1.0]]))
+    data = _splat(np.zeros(2, dtype=np.float32), scales)
+
+    keep = clean_splat.anisotropy_keep(data, FIELDS, 20.0)
+
+    assert keep.tolist() == [True, False]
+
+
+def test_scale_filter_is_relative_to_the_population() -> None:
+    scales = np.log(np.tile(np.array([1.0, 2.0, 3.0, 400.0])[:, None], (1, 3)))
+    data = _splat(np.zeros(4, dtype=np.float32), scales)
+
+    keep = clean_splat.scale_keep(data, FIELDS, 0.75)
+
+    assert keep.tolist() == [True, True, True, False]
+
+
+def test_missing_property_is_reported_not_ignored() -> None:
+    data = _splat(np.zeros(2, dtype=np.float32))
+
+    with pytest.raises(clean_splat.PlyError, match="scale_0"):
+        clean_splat.anisotropy_keep(data, ["x", "y", "z", "opacity"], 20.0)
+
+
+def test_stages_compose_and_write_a_smaller_file(tmp_path: Path) -> None:
+    logits = np.concatenate([np.full(50, 4.0), np.full(50, -8.0)]).astype(np.float32)
+    data = _splat(logits)
+    source = tmp_path / "in.ply"
+    target = tmp_path / "out.ply"
+    clean_splat.write_ply(source, data, FIELDS)
+
+    assert clean_splat.main([str(source), "-o", str(target), "--opacity", "0.05"]) == 0
+
+    kept, _ = clean_splat.read_ply(target)
+    assert len(kept) == 50
+    assert target.stat().st_size < source.stat().st_size
+
+
+def test_dry_run_writes_nothing(tmp_path: Path) -> None:
+    data = _splat(np.full(10, 4.0, dtype=np.float32))
+    source = tmp_path / "in.ply"
+    target = tmp_path / "out.ply"
+    clean_splat.write_ply(source, data, FIELDS)
+
+    assert clean_splat.main([str(source), "-o", str(target), "--dry-run"]) == 0
+    assert not target.exists()
+
+
+def test_refuses_to_write_an_empty_splat(tmp_path: Path) -> None:
+    data = _splat(np.full(10, -20.0, dtype=np.float32))
+    source = tmp_path / "in.ply"
+    target = tmp_path / "out.ply"
+    clean_splat.write_ply(source, data, FIELDS)
+
+    assert clean_splat.main([str(source), "-o", str(target), "--opacity", "0.5"]) == 1
+    assert not target.exists()
+
+
+def test_rejects_an_out_of_range_opacity(tmp_path: Path) -> None:
+    source = tmp_path / "in.ply"
+    clean_splat.write_ply(source, _splat(np.zeros(4, dtype=np.float32)), FIELDS)
+
+    assert clean_splat.main([str(source), "--opacity", "1.5"]) == 2

--- a/tests/test_export_script.py
+++ b/tests/test_export_script.py
@@ -25,7 +25,17 @@ def _make_stub_binaries(bin_dir: Path, log_path: Path) -> None:
             'echo "$0 $@" >> "$MINI_MESH_STUB_LOG"',
         ]
     )
-    for name in ("sdf-extract-mesh", "sdf-texture-mesh", "sdf-render", "ns-export", "ns-render"):
+    # "python" is stubbed too: the splat cleanup step runs the real clean_splat.py
+    # otherwise, and these tests write placeholder PLY files it rightly rejects.
+    names = (
+        "sdf-extract-mesh",
+        "sdf-texture-mesh",
+        "sdf-render",
+        "ns-export",
+        "ns-render",
+        "python",
+    )
+    for name in names:
         script_path = bin_dir / name
         script_path.write_text(script_body, encoding="utf-8")
         script_path.chmod(0o755)
@@ -1070,6 +1080,77 @@ class TestExportScriptNerfWorkflow:
         assert "--obb-center 1 2 3" in log
         assert "--obb-rotation 4 5 6" in log
         assert "--obb-scale 7 8 9" in log
+
+    def _run_splat_export_with_cleanup(
+        self, tmp_path: Path, extra_args: list[str]
+    ) -> tuple[subprocess.CompletedProcess[str], str]:
+        """Export a splat with an output file already in place so cleanup has a target."""
+        repo_root = Path(__file__).resolve().parents[1]
+        exp_path = tmp_path / "train" / "scene" / "splatfacto" / "run"
+        exp_path.mkdir(parents=True, exist_ok=True)
+        (exp_path / "config.yml").write_text("dummy: true\n", encoding="utf-8")
+        (exp_path / "splat.ply").write_text("ply\n", encoding="utf-8")
+
+        log_path = tmp_path / "stub.log"
+        bin_dir = tmp_path / "bin"
+        _make_stub_binaries(bin_dir, log_path)
+
+        env_overrides = {
+            "PATH": f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}",
+            "MINI_MESH_STUB_LOG": str(log_path),
+        }
+
+        result = _run_export_script(
+            repo_root, exp_path, ["--overwrite", *extra_args], env_overrides
+        )
+        log = log_path.read_text(encoding="utf-8") if log_path.exists() else ""
+        return result, log
+
+    def test_splat_export_cleans_the_exported_splat_by_default(self, tmp_path: Path) -> None:
+        """A splat export should hand its output to clean_splat.py without being asked."""
+        result, log = self._run_splat_export_with_cleanup(tmp_path, [])
+        assert result.returncode == 0, result.stderr
+        assert "clean_splat.py" in log
+        assert "splat.ply" in log
+
+    def test_no_clean_skips_the_cleanup_step(self, tmp_path: Path) -> None:
+        """--no-clean should leave the exported splat exactly as nerfstudio wrote it."""
+        result, log = self._run_splat_export_with_cleanup(tmp_path, ["--no-clean"])
+        assert result.returncode == 0, result.stderr
+        assert "ns-export gaussian-splat" in log
+        assert "clean_splat.py" not in log
+
+    def test_clean_flags_are_forwarded_without_their_prefix(self, tmp_path: Path) -> None:
+        """--clean-opacity is the export-level spelling of clean_splat.py's --opacity."""
+        result, log = self._run_splat_export_with_cleanup(
+            tmp_path, ["--clean-opacity", "0.1", "--clean-sor"]
+        )
+        assert result.returncode == 0, result.stderr
+        cleanup = [line for line in log.splitlines() if "clean_splat.py" in line]
+        assert len(cleanup) == 1
+        assert "--opacity 0.1" in cleanup[0]
+        assert "--sor" in cleanup[0]
+        assert "--clean-" not in cleanup[0]
+
+    def test_mesh_export_does_not_run_the_splat_cleanup(self, tmp_path: Path) -> None:
+        """Cleanup is splat-specific; a Poisson mesh must not be routed through it."""
+        repo_root = Path(__file__).resolve().parents[1]
+        exp_path = tmp_path / "train" / "scene" / "nerfacto"
+        exp_path.mkdir(parents=True, exist_ok=True)
+        (exp_path / "config.yml").write_text("dummy: true\n", encoding="utf-8")
+
+        log_path = tmp_path / "stub.log"
+        bin_dir = tmp_path / "bin"
+        _make_stub_binaries(bin_dir, log_path)
+
+        env_overrides = {
+            "PATH": f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}",
+            "MINI_MESH_STUB_LOG": str(log_path),
+        }
+
+        result = _run_export_script(repo_root, exp_path, [], env_overrides)
+        assert result.returncode == 0, result.stderr
+        assert "clean_splat.py" not in log_path.read_text(encoding="utf-8")
 
 
 class TestExportScriptOrbitFramesSdfWorkflow:

--- a/webui.py
+++ b/webui.py
@@ -108,6 +108,8 @@ def test_cmd(cmd: str, run_cmd: str) -> Optional[str]:
         "--hdr",
         "--skip",
         "--overwrite",
+        "--no-clean",
+        "--clean-",
     ]
     video_pattern = r"video\s+(.*?)(?=\s+(sfm|process|train|export)\b|$)"
     video_match = re.search(video_pattern, cmd)


### PR DESCRIPTION
## Summary

An MCMC checkpoint holds exactly `cap_max` Gaussians and exports every one that survives the ROI crop and the 1/255 cull, so a 1M-Gaussian run lands at roughly 200 MB whatever the scene. Dropping everything below 0.05 opacity takes 13.6% of the Gaussians out of such an export, 207 MB down to 178 MB on `gaudi_fountain`, and the same cut applied to checkpoints moved LPIPS by less than a tenth of the per-image spread on both scenes measured.

Closes: #30

## Changes

- `scripts/clean_splat.py`: reads and writes the PLY with numpy alone, so it needs neither torch nor a checkpoint and runs on any exported splat. Four filters compose: opacity, a quantile-relative size cut (scene scale is arbitrary, so an absolute threshold would not port), an axis-ratio cut for needles, and statistical outlier removal on the centres. `--dry-run` reports what each stage would take without writing.
- Only the opacity cut runs by default at 0.05. The other three are unmeasured, so they stay behind flags, and the needle cut in particular is not the free win it looks like: 46% of a real export sits above an axis ratio of 20, and a thin Gaussian is how a splat represents thin structure.
- `scripts/export.sh` runs the filter on every splat it writes, and takes `--no-clean` plus `--clean-*` passthrough flags.
- `scripts/export.sh` also stops calling bare `python` for the splatfacto-w exporter. `scripts/env.sh` puts a torch-less dev venv first on PATH, which is why that export has never worked from a repo checkout; the new helper probes candidates for torch instead of trusting the name or a shebang.

## Type of Change

- [x] New feature
- [x] Bug fix
- [x] Documentation update

## Testing

- [x] Ran `make check` (required)
- [x] Added/updated tests

10 tests cover the filter itself (round trip, ascii input, sigmoid rather than logit opacity, needle removal, quantile-relative scaling, missing properties, stage composition, dry run, empty result, out-of-range threshold). Four more cover the wiring in `export.sh`: cleanup by default, `--no-clean`, flag forwarding, and that mesh exports are left alone.

Also run against two real nerfstudio exports from `gaudi_fountain`, a 100k-cap and a 1M-cap MCMC run, including a write-then-reread to confirm the output parses back to the same Gaussians.

## Checklist

- [x] I have read the Contributing Guidelines
- [x] My code follows the existing style (2-space indent for Bash, 4-space for Python)
- [x] I have updated documentation if needed (README, webui.py, Docker wrappers)
- [x] New flags are reflected in all entry points (`scripts/run.sh`, `webui.py`, `docker/run.sh`)

Docker wrappers pass arguments through untouched, so they needed no change; `webui.py` gained the flags in its export allowlist.
