### PR TITLE
fix(export): crop only when a box is asked for

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,12 @@ For NeRF/ngp models, request several exporters by repeating `--method` or using
 a comma-separated value, for example `export --method poisson,orbit-frames`. For SDF and splat models,
 `orbit-frames` is additive to the normal export.
 
+**Cropping:** nothing is cropped unless you ask. Passing any of `--obb-center`, `--obb-rotation`, or
+`--obb-scale` turns on an oriented box and the other two fall back to `0 0 0`, `0 0 0`, and `1 1 1`; nerfstudio
+ignores a partial triplet, so one flag has to supply all three. The box spans ±scale/2 about its centre, in the
+frame the dataparser produced by auto-scaling the cameras, which is not a frame you can guess: pick the numbers by
+looking at the result rather than by reasoning about the capture.
+
 **Splat cleanup:** every exported splat PLY goes through `scripts/clean_splat.py` before it lands on disk. Only the
 opacity filter runs by default, dropping Gaussians below 0.05, which takes a 1M-Gaussian MCMC export from 207 MB to
 178 MB and a 100k one from 21.5 MB to 20.4 MB. The threshold comes from pruning checkpoints at several values and

--- a/scripts/export.sh
+++ b/scripts/export.sh
@@ -245,9 +245,10 @@ function show_help {
   echo "                              --appearance-mode <mean|index>            Appearance bake mode for splatfacto-w-light (default: mean)"
   echo "                              --appearance-idx <int>                    Camera index for appearance embedding"
   echo "                              --method <string[,string...]>             Export method(s): poisson, tsdf, pointcloud, orbit-frames (default: poisson for NeRF)"
-  echo "                              --obb-center <float float float>          Center of oriented bounding-box (default: 0 0 0)"
-  echo "                              --obb-rotation <float float float>        Rotation of oriented bounding-box (default: 0 0 0)"
-  echo "                              --obb-scale <float float float>           Scale of oriented bounding-box (default: 1 1 1)"
+  echo "                              --obb-center <float float float>          Center of crop box, turns cropping on (default: 0 0 0)"
+  echo "                              --obb-rotation <float float float>        Rotation of crop box, turns cropping on (default: 0 0 0)"
+  echo "                              --obb-scale <float float float>           Size of crop box, turns cropping on (default: 1 1 1)"
+  echo "                                                                        Nothing is cropped unless one of these is given"
   echo "                              --downscale-factor <int>                  Image downscale factor for TSDF extraction (default: 2)"
   echo "                              --no-clean                                Skip splat cleanup after export"
   echo "                              --clean-opacity <float>                   Drop Gaussians below this opacity (default: 0.05)"
@@ -290,9 +291,14 @@ clean_splat=true
 nerf_methods=()
 method_requested=false
 orbit_frames_requested=false
+# These are the values used when the user asks for a box, not a default box.
+# nerfstudio crops only when all three flags are given (exporter.py:619), so
+# passing them unconditionally would clip every export to a half-unit cube in a
+# frame the dataparser picked by auto-scaling the cameras.
 nerf_obb_center=(0 0 0)
 nerf_obb_rotation=(0 0 0)
 nerf_obb_scale=(1 1 1)
+nerf_obb_requested=false
 mesh_only=false
 texture_only=false
 input_mesh_filename=""
@@ -387,6 +393,7 @@ while [ $i -lt ${#export_args[@]} ]; do
       ;;
     --obb-center|--obb-rotation|--obb-scale)
       require_args "${export_args[$i]}" 3 "$remaining"
+      nerf_obb_requested=true
       case "${export_args[$i]}" in
         --obb-center)
           nerf_obb_center=("${export_args[$((i+1))]}" "${export_args[$((i+2))]}" "${export_args[$((i+3))]}")
@@ -448,6 +455,17 @@ while [ $i -lt ${#export_args[@]} ]; do
   esac
 done
 
+# One box for every exporter. Any single flag turns the box on and the other two
+# keep their values, since nerfstudio ignores a partial triplet entirely.
+nerf_obb_args=()
+if [ "$nerf_obb_requested" = true ]; then
+  nerf_obb_args=(
+    --obb-center "${nerf_obb_center[@]}"
+    --obb-rotation "${nerf_obb_rotation[@]}"
+    --obb-scale "${nerf_obb_scale[@]}"
+  )
+fi
+
 if [ -f "$exp_path/config.yml" ]; then
   if [[ ${#export_args[@]} -gt 0 ]]; then
     echo "[INFO]: Export args: ${export_args[*]}"
@@ -475,18 +493,14 @@ if [ -f "$exp_path/config.yml" ]; then
           run_cmd "$(nerfstudio_python)" "$script_dir/export_splatfactow.py" \
             --load-config "$exp_path/config.yml" \
             --output-dir "$exp_path" \
-            --obb-center "${nerf_obb_center[@]}" \
-            --obb-rotation "${nerf_obb_rotation[@]}" \
-            --obb-scale "${nerf_obb_scale[@]}" \
+            "${nerf_obb_args[@]}" \
             "${splatfactow_args[@]}" \
             "${nerf_args[@]}"
         else
           run_cmd ns-export gaussian-splat \
             --load-config "$exp_path/config.yml" \
             --output-dir "$exp_path" \
-            --obb-center "${nerf_obb_center[@]}" \
-            --obb-rotation "${nerf_obb_rotation[@]}" \
-            --obb-scale "${nerf_obb_scale[@]}" \
+            "${nerf_obb_args[@]}" \
             "${nerf_args[@]}"
         fi
         clean_splat_output "$nerf_output_path"
@@ -502,9 +516,7 @@ if [ -f "$exp_path/config.yml" ]; then
             run_cmd ns-export pointcloud \
               --load-config "$exp_path/config.yml" \
               --output-dir "$exp_path" \
-              --obb-center "${nerf_obb_center[@]}" \
-              --obb-rotation "${nerf_obb_rotation[@]}" \
-              --obb-scale "${nerf_obb_scale[@]}" \
+              "${nerf_obb_args[@]}" \
               --std-ratio 1 \
               "${nerf_args[@]}"
           elif [ "$method" = tsdf ]; then
@@ -520,9 +532,7 @@ if [ -f "$exp_path/config.yml" ]; then
               --load-config "$exp_path/config.yml" \
               --output-dir "$exp_path" \
               --save-point-cloud True \
-              --obb-center "${nerf_obb_center[@]}" \
-              --obb-rotation "${nerf_obb_rotation[@]}" \
-              --obb-scale "${nerf_obb_scale[@]}" \
+              "${nerf_obb_args[@]}" \
               --std-ratio 1 \
               --density-quantile 0.01 \
               "${nerf_args[@]}"

--- a/tests/test_export_script.py
+++ b/tests/test_export_script.py
@@ -1152,6 +1152,52 @@ class TestExportScriptNerfWorkflow:
         assert result.returncode == 0, result.stderr
         assert "clean_splat.py" not in log_path.read_text(encoding="utf-8")
 
+    def _run_and_log(
+        self, tmp_path: Path, model: str, extra_args: list[str]
+    ) -> tuple[subprocess.CompletedProcess[str], str]:
+        """Export one experiment of the given model and return the stub log."""
+        repo_root = Path(__file__).resolve().parents[1]
+        exp_path = tmp_path / "train" / "scene" / model
+        exp_path.mkdir(parents=True, exist_ok=True)
+        (exp_path / "config.yml").write_text("dummy: true\n", encoding="utf-8")
+
+        log_path = tmp_path / "stub.log"
+        bin_dir = tmp_path / "bin"
+        _make_stub_binaries(bin_dir, log_path)
+
+        env_overrides = {
+            "PATH": f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}",
+            "MINI_MESH_STUB_LOG": str(log_path),
+        }
+
+        result = _run_export_script(repo_root, exp_path, extra_args, env_overrides)
+        log = log_path.read_text(encoding="utf-8") if log_path.exists() else ""
+        return result, log
+
+    def test_splat_export_crops_nothing_by_default(self, tmp_path: Path) -> None:
+        """nerfstudio's default is no crop box; export.sh must not invent one."""
+        result, log = self._run_and_log(tmp_path, "splatfacto", [])
+        assert result.returncode == 0, result.stderr
+        assert "ns-export gaussian-splat" in log
+        assert "--obb-" not in log
+
+    def test_poisson_export_crops_nothing_by_default(self, tmp_path: Path) -> None:
+        """The same default applies to the mesh exporters, which share the flags."""
+        result, log = self._run_and_log(tmp_path, "nerfacto", [])
+        assert result.returncode == 0, result.stderr
+        assert "ns-export poisson" in log
+        assert "--obb-" not in log
+
+    def test_one_obb_flag_turns_cropping_on_with_defaults_for_the_rest(
+        self, tmp_path: Path
+    ) -> None:
+        """nerfstudio ignores a partial triplet, so one flag has to supply all three."""
+        result, log = self._run_and_log(tmp_path, "splatfacto", ["--obb-scale", "2", "2", "2"])
+        assert result.returncode == 0, result.stderr
+        assert "--obb-scale 2 2 2" in log
+        assert "--obb-center 0 0 0" in log
+        assert "--obb-rotation 0 0 0" in log
+
 
 class TestExportScriptOrbitFramesSdfWorkflow:
     """Tests for image-sequence render export on SDF-style methods."""


### PR DESCRIPTION
## Summary

`export.sh` passed `--obb-center 0 0 0 --obb-rotation 0 0 0 --obb-scale 1 1 1` to every nerfstudio exporter. Those look like inert defaults and are not: nerfstudio defaults all three to `None` and crops only when all three are set (`exporter.py:619`), and `OrientedBox.within` spans ±scale/2. So every export this project has produced was clipped to a half-unit cube centred on wherever the dataparser's auto-scaling put the origin.

Based on `feat/splat-cleanup` (#31) to avoid conflicting edits in `export.sh`; it will retarget to `main` when that merges.

Closes: #32

## Changes

- The OBB flags now turn cropping on instead of configuring a box that is always applied. Supplying any one of them fills the other two from the old defaults, because nerfstudio ignores a partial triplet and `--obb-scale 2 2 2` should keep working alone.
- README documents that nothing is cropped unless asked, and that the box lives in the dataparser's frame rather than one you can reason about from the capture.

## Evidence

15 splatfacto-mcmc runs at `max_gs_num` 250000. The box removed more than the 1/255 opacity cull did in 14 of them.

| scene | exported | crop | crop at opacity ≥ 0.05 | cull |
|---|---|---|---|---|
| gaudi_wall | 58,852 | 190,825 | 172,168 | 323 |
| gaudi_ceiling | 121,544 | 127,433 | 118,318 | 1,023 |
| gaudi_chair_1 | 90,796 | 152,986 | 82,433 | 6,218 |
| gaudi_chair_1_b | 62,587 | 172,278 | 57,450 | 15,135 |
| gaudi_chair_3 | 71,525 | 162,630 | 55,374 | 15,845 |

`ns-eval` could not have caught this. It scores the checkpoint, which has neither the crop nor the cull, so a scene can score 0.12 LPIPS and ship a PLY holding 24% of its Gaussians.

## Type of Change

- [x] Bug fix
- [x] Documentation update

## Testing

- [x] Ran `make check` (required)
- [x] Added/updated tests

Three new tests: splat export forwards no `--obb-` flags by default, poisson export likewise, and a lone `--obb-scale 2 2 2` still produces the full triplet. The existing test that passes all three and asserts each appears exactly once still passes unchanged.

## Checklist

- [x] I have read the Contributing Guidelines
- [x] My code follows the existing style (2-space indent for Bash, 4-space for Python)
- [x] I have updated documentation if needed (README, webui.py, Docker wrappers)
- [x] New flags are reflected in all entry points (`scripts/run.sh`, `webui.py`, `docker/run.sh`)

No new flags; the existing ones changed meaning, and `webui.py` already allows them.

## Follow-up

Every splat exported before this needs re-exporting. That is running now for the 15 Gaudi scenes.
