### PR TITLE
docs: add perceptual evaluation methodology for splats

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,12 @@ For NeRF/ngp models, request several exporters by repeating `--method` or using
 a comma-separated value, for example `export --method poisson,orbit-frames`. For SDF and splat models,
 `orbit-frames` is additive to the normal export.
 
+Orbit frames are written as JPEG, which is what a web viewer wants. Frames that will be scored against other
+renders need `export --method orbit-frames --orbit-image-format png`: JPEG error largely cancels between two
+near-identical images and decorrelates as they separate, so it grows with the effect being measured rather than
+sitting under it as a constant floor. `docs/evaluation.md` has the measurements. The flag reaches NeRF and splat
+orbits; `sdf-render` has no image format option and its frames stay JPEG.
+
 **Cropping:** nothing is cropped unless you ask. Passing any of `--obb-center`, `--obb-rotation`, or
 `--obb-scale` turns on an oriented box and the other two fall back to `0 0 0`, `0 0 0`, and `1 1 1`; nerfstudio
 ignores a partial triplet, so one flag has to supply all three. The box spans ±scale/2 about its centre, in the

--- a/README.md
+++ b/README.md
@@ -311,7 +311,9 @@ Orbit frames are written as JPEG, which is what a web viewer wants. Frames that 
 renders need `export --method orbit-frames --orbit-image-format png`: JPEG error largely cancels between two
 near-identical images and decorrelates as they separate, so it grows with the effect being measured rather than
 sitting under it as a constant floor. `docs/evaluation.md` has the measurements. The flag reaches NeRF and splat
-orbits; `sdf-render` has no image format option and its frames stay JPEG.
+orbits; `sdf-render` has no image format option and its frames stay JPEG. A frame directory written in one
+format is not reused for the other: the export skips it and says so, and `--overwrite` clears the old frames
+before rendering rather than leaving a sequence that is part JPEG and part PNG.
 
 **Cropping:** nothing is cropped unless you ask. Passing any of `--obb-center`, `--obb-rotation`, or
 `--obb-scale` turns on an oriented box and the other two fall back to `0 0 0`, `0 0 0`, and `1 1 1`; nerfstudio

--- a/README.md
+++ b/README.md
@@ -318,8 +318,14 @@ opacity filter runs by default, dropping Gaussians below 0.05. What that saves d
 the settings: across 15 splatfacto-mcmc exports it removed between 4.9% and 62% of the Gaussians, median 28%. Object
 captures sit at the top of that range because the model fills the empty space around the subject with faint
 Gaussians, and outdoor walkthroughs where every direction has content sit at the bottom. The threshold comes from
-pruning checkpoints at several values and re-running `ns-eval`: 0.05 moved LPIPS by less than a tenth of the
-per-image spread on both scenes tried, while 0.1 cost a full spread on the sharper one.
+pruning checkpoints at several values and testing matched pairs frame by frame: at 0.05 the paired LPIPS change is
++0.0007 on a cluttered outdoor capture and +0.0059 on a sharp object capture, with the sign holding on every frame
+of both, and at 0.1 it is +0.0042 and +0.0373. Scored against the unpruned render at the same poses instead of
+against photographs, 0.05 moves the image by 0.0032 and 0.0078 LPIPS (43 and 42 dB) and 0.1 by 0.020 and 0.054
+(around 32 dB). Those are measured changes in objective metrics and not established perceptual costs; whether the
+median 28% saving is worth them is an open question. Earlier guidance here called 0.1 free on the outdoor capture,
+which compared the effect to the per-image spread rather than to its own paired noise and so buried a small
+consistent regression. See `docs/evaluation.md`.
 
 Use `export --no-clean` to keep the raw output, `--clean-opacity <float>` to move the threshold, and
 `--clean-max-scale-quantile <q>`, `--clean-max-anisotropy <ratio>`, or `--clean-sor` to switch on the size, needle,

--- a/README.md
+++ b/README.md
@@ -322,10 +322,13 @@ pruning checkpoints at several values and testing matched pairs frame by frame: 
 +0.0007 on a cluttered outdoor capture and +0.0059 on a sharp object capture, with the sign holding on every frame
 of both, and at 0.1 it is +0.0042 and +0.0373. Scored against the unpruned render at the same poses instead of
 against photographs, 0.05 moves the image by 0.0032 and 0.0078 LPIPS (43 and 42 dB) and 0.1 by 0.020 and 0.054
-(around 32 dB). Those are measured changes in objective metrics and not established perceptual costs; whether the
-median 28% saving is worth them is an open question. Earlier guidance here called 0.1 free on the outdoor capture,
-which compared the effect to the per-image spread rather than to its own paired noise and so buried a small
-consistent regression. See `docs/evaluation.md`.
+(around 32 dB). Those are measured changes in objective metrics and not established perceptual costs. 0.05 is a
+provisional default: what is established is the shape of the tradeoff rather than the right point on it, since
+moving to 0.1 removes a further 18 to 30 percentage points of Gaussians and multiplies the deviation from the
+unpruned render by six to seven. Picking a point on that curve needs a viewer study or an acceptance bound set in
+advance, and there is neither. Earlier guidance here called 0.1 free on the outdoor capture, which compared the
+effect to the per-image spread rather than to its own paired noise and so buried a small consistent regression.
+See `docs/evaluation.md`.
 
 Use `export --no-clean` to keep the raw output, `--clean-opacity <float>` to move the threshold, and
 `--clean-max-scale-quantile <q>`, `--clean-max-anisotropy <ratio>`, or `--clean-sor` to switch on the size, needle,

--- a/README.md
+++ b/README.md
@@ -440,6 +440,7 @@ For advanced tuning (BRDF flags, regularizers, NeuS parameters), see **[docs/tro
 - **[Methods & Models](docs/methods_and_models.md)** — How NeuS, NeRF, and other methods work
 - **[BRDF & Shading](docs/brdf_and_shading_effects.md)** — Handling reflective and glossy surfaces
 - **[Examples](docs/examples.md)** — Additional usage examples
+- **[Evaluating splat quality](docs/evaluation.md)** — Why PSNR/SSIM/LPIPS undersell splat quality differences
 
 ## Demos
 

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -108,14 +108,25 @@ with spherical harmonics removed during training, not as a container applied
 afterwards. Nothing published covers our version of the question.
 
 **The frame-count experiment.** Ran at 106 and 212 training views against a
-pinned 11-frame held-out set, and came back a tie: PSNR 20.05 against 20.10,
-SSIM 0.519 against 0.532, LPIPS 0.3645 against 0.3677, all inside a per-image
-spread of 0.063 to 0.070. Doubling the training views moved nothing, and moved
-LPIPS the wrong way. This null is the one least troubled by the correlation
-ceiling, since the gap is a twentieth of the noise rather than a close call, but
-it is still a statement about what three 2D metrics can see. MUGSQA's
-view-quantity axis is the closest prior work and it scores with 2D metrics too,
-so it inherits the same limit.
+pinned 11-frame held-out set: PSNR 20.05 against 20.10, SSIM 0.519 against
+0.532, LPIPS 0.3645 against 0.3677. Both configurations were scored on the same
+11 frames, which means the comparison is paired and the per-image standard
+deviation is the wrong yardstick for it.
+
+That deviation, 0.063 to 0.070 on LPIPS, is dominated by how hard each frame is,
+and frame difficulty is shared between the two runs. It cancels in the
+per-frame differences. A change of 0.003 that pointed the same way on all 11
+frames would be a real effect hiding inside a spread twenty times its size,
+and comparing the gap to the marginal spread cannot tell that apart from noise.
+`ns-eval` reports only aggregates, so the per-frame values needed to settle it
+were never written down.
+
+This is not a frame-count problem. Every "inside the spread, therefore no
+difference" verdict in this project was reached the same way, including the ones
+for opacity pruning, `rasterize_mode` and appearance embeddings. Pairing raises
+sensitivity, so the direction of the error is one-sided: effects called noise
+may be real, while effects already called real stay real. Re-running eval with
+per-frame output is cheap and comes before trusting any of those nulls.
 
 ## What to measure instead
 
@@ -165,8 +176,19 @@ The proposed experiment, in order:
    metric can be scored against.
 3. **Select on one half, validate on the other.** Split the pairs into a
    selection set and a held-out set before looking at any of them. Use the
-   selection set to pick among DOVER, DISTS (0.73) and CW-SSIM (0.74), then
-   score the winner once on the held-out set. Count only pairs where the rater
+   selection set to pick a metric, then score the winner once on the held-out
+   set.
+
+   The candidates have to be no-reference, because an A/B of two orbits has no
+   ground truth to reference. A novel orbit path has no captured photo to
+   compare against, so a full-reference metric has nothing to score. DISTS and
+   CW-SSIM beat PSNR and LPIPS in the tables above and are useless here for that
+   reason: scored A against B they give a symmetric distance with no direction,
+   and scored against the unfiltered export as reference they hand it the win by
+   construction. That leaves DOVER, VSFA, FAST-VQA and Q-Align, which score each
+   orbit on its own. DISTS and CW-SSIM can only be tested on held-out frames
+   where a real photo exists, which is a different experiment against different
+   stimuli than the one a viewer judged. Count only pairs where the rater
    was self-consistent and expressed a preference, and fix the acceptance
    threshold in advance rather than after seeing the number. Adopting a metric
    on the same comparisons that chose it measures nothing.

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -425,14 +425,41 @@ So the fine end ranks nobody. FID resolves nothing, CMMD resolves one step, KID
 resolves two, and which behaviour is correct depends on a threshold nobody has
 set.
 
-What does separate them needs no labels at all, because it is about the
-estimators rather than the images. FID's level falls 12.8 points between 28 and
-112 frames, more than twice the range of the entire ladder, so it cannot be read
-as a number and cannot be compared across differing frame counts. KID returns
--6.4 at 36 frames, a negative squared distance, which is legal for an unbiased
-estimator and useless for ordering anything. CMMD shows neither pathology. On
-that basis, and only that basis, CMMD is the one to reach for, with the frame
-count held fixed across everything being compared.
+What does separate them needs no labels, because it is about the estimators
+rather than the images. Two things, and the first version of one of them was
+wrong.
+
+FID's absolute level falls 12.8 points between 28 and 112 frames, more than
+twice the range of the whole ladder, so it cannot be read as a number and two
+configurations scored at different frame counts cannot be compared at all. The
+paired steps survive because the shared bootstrap cancels the part of that drift
+the two runs have in common. Nothing rescues the level.
+
+The second is discriminability under matched samples. Each metric's own
+bootstrap supplies its sampling deviation, on the same frames under the same
+resampling, so the ratio of a step to that deviation compares estimators in
+spite of their different units. On the four steps where the renders genuinely
+differ:
+
+| step             | FID   | KID  | CMMD  |
+| ---------------- | ----- | ---- | ----- |
+| gaudi 0.02→0.05  | 4.15  | 0.31 | 6.32  |
+| gaudi 0.05→0.1   | 7.97  | 3.77 | 12.70 |
+| r2d2 0.02→0.05   | 6.40  | 2.90 | 15.90 |
+| r2d2 0.05→0.1    | 17.98 | 7.50 | 15.72 |
+
+CMMD leads in three of the four and KID trails in all four, while FID takes the
+largest step on r2d2. That is the comparison this conclusion needed. An earlier
+version rested it on KID returning -6.4 at 36 frames, which does not support
+anything: a negative value is exactly what an unbiased U-statistic is entitled
+to produce, it bars reading that point estimate as an absolute distance, and it
+leaves untouched the paired differences the tables above are built from. CMMD's
+estimator is the biased V-statistic and nonnegative by construction, so never
+going negative is a property of its formula rather than evidence of stability.
+
+The fine steps are left out of that table on purpose. A higher ratio there would
+mean only that an estimator separates images that barely differ, and whether
+that is a virtue is the question no bound has settled.
 
 All three resolve the coarse rungs cleanly and agree on direction there, which
 is the regime where the choice of metric stops mattering.
@@ -498,8 +525,7 @@ What it buys is a real decision. Both scenes start from a 1M cap. Pruning at
 0.05 leaves 628k Gaussians on gaudi and 619k on r2d2, a cut of roughly 38% in
 both, and moves the delivered image by 0.0032 and 0.0078 LPIPS at 42 to 43 dB.
 Pruning at 0.1 leaves 446k and 324k, cuts of 55% and 68%, and moves it by 0.020
-and 0.054 at around 32 dB. The r2d2 cell at 0.1 is the only one that looks like
-a real cost.
+and 0.054 at around 32 dB.
 
 The fine rungs come out very small indeed: 61 dB on gaudi and 68 dB on r2d2 at
 0.01. That says nothing about the threshold actually being shipped. The step

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -711,8 +711,11 @@ count are float32 and carry the 0.0002 noted above, which is two orders of
 magnitude under the drift being discussed.
 
 Three limits apply to all of the above. These are training views, which the
-model was fit to, so they understate every degradation. The reference set is our
-own capture frames, tourists included, so a model that correctly drops a
+model was fit to, so nothing here establishes how these transforms behave on
+held-out or delivery poses. Which way the difference runs is not known either:
+pruning is applied after training and can cost a seen pose more than a novel
+one as easily as less, so these numbers are not lower bounds. The reference set
+is our own capture frames, tourists included, so a model that correctly drops a
 transient is penalised for it. And an interval spanning zero means the test
 could not resolve that step at this sample size, which is not the same as the
 step being free.
@@ -1004,13 +1007,13 @@ The proposed experiment, in order:
    metric that would work for other people, and one insensitive rater's
    indifference is not evidence that anybody else would miss the difference.
    Nothing in the design separates any of those from the population case. So
-   the experiment as described settles what we default to and nothing wider,
-   and each outcome should be written down that way. Treating any of the three
-   as a claim about viewers needs a second rater, recruited independently and
-   scoring the same held-out pairs, and that goes double for wiring a metric in
-   after `export` for every asset we ship. Short of it the winner stays a
-   diagnostic reported next to `ns-eval` rather than a criterion anything is
-   decided on.
+   each outcome should be written down as what that rater saw, and none of them
+   sets a default for assets other people look at. Turning any of the three
+   into a decision needs a second rater, recruited independently and scoring the
+   same held-out pairs. Short of that the defaults stay where they are, the
+   winner is a diagnostic reported next to `ns-eval`, and the honest summary of
+   a completed single-rater run is that one person could or could not tell these
+   apart.
 4. **Build stimuli only if 1 to 3 leave a real gap.** MUGSQA covers the input
    axes and released its data, so what would remain is attribute-based pruning
    and container quantisation at fixed training. That is a much smaller build

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -828,10 +828,16 @@ source puts the encoder's error at 0.00795 LPIPS and 48.5 dB on r2d2, 0.00597
 and 46.0 dB on gaudi. None of that comes from the rendering: the JPEG pass is
 byte for byte identical to those re-encodings on all 147 and 112 frames, so both
 passes drew the same pixels and the encoder is the only thing left between them.
-The repository's own orbit renderer defaults to quality 100, so 0.00795 bounds
-what that default costs rather than measuring it. Against a photograph the
-number is nothing, since renders sit around 22 dB from those, and against
-another render at 61 to 68 dB it is overwhelming. The artifacts
+The repository's own orbit renderer defaults to quality 100, which is a
+different setting and not a safer one. Encoding the same frames across the range
+gives LPIPS of 0.01941, 0.01084, 0.00795, 0.00802 and 0.00843 on r2d2 at q80,
+q90, q95, q98 and q100, and 0.01954, 0.00983, 0.00597, 0.00430 and 0.00396 on
+gaudi. PSNR climbs with the setting on both scenes, 44.7 to 50.4 dB and 41.7 to
+49.4 dB, and LPIPS does not: on r2d2 it bottoms out at q95 and rises again, so
+the q100 default costs 6% more LPIPS than q95 while writing files 2.2 times the
+size. The two scenes disagree about the direction, which is the point. Against a
+photograph the number is nothing, since renders sit around 22 dB from those, and
+against another render at 61 to 68 dB it is overwhelming. The artifacts
 mostly cancel between two nearly identical images and decorrelate as the images
 separate, so the contamination grows with the rung instead of sitting under
 everything as a constant floor: seventeen times at 0.01, six at 0.02, and still
@@ -979,10 +985,17 @@ The proposed experiment, in order:
 
    Three outcomes are worth naming ahead of time. A metric clears the threshold,
    which makes it a candidate rather than a default. Nothing clears it, which
-   means these calls are not metric-decidable for us and file size decides. Or
-   the rater is mostly indifferent, which settles the underlying question
-   without a metric: if 250k and 500k are indistinguishable on an orbit, ship
-   250k.
+   means these calls cannot be automated with these candidates. Or the rater is
+   mostly indifferent, which settles the underlying question without a metric:
+   if 250k and 500k are indistinguishable on an orbit, ship 250k.
+
+   The second outcome is not a licence to ship the smaller file. A metric can
+   fail by mispredicting preferences the rater expressed unanimously, and those
+   preferences do not evaporate when the metric that was supposed to reproduce
+   them does. Where a pair drew a stable preference, follow it. File size
+   decides the pairs the rater could not separate and the pairs never rated,
+   and pairs that matter and stay unresolved are an argument for rating more of
+   them rather than for a tiebreaker.
 
    With one rater all three are statements about that rater, and none is a
    statement about viewers. Repeats measure whether a rater agrees with

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -1004,9 +1004,22 @@ these models, so the numbers appear to be off-the-shelf pretrained weights
 applied to rendered videos. That is worth confirming against their code before
 leaning on it.
 
-If it holds, adopting it is cheap. These models take a video, need no reference,
-and we already render orbit videos with `ns-render`. The change is one more step
-after export, not a new benchmark.
+If it holds, adopting it is cheaper than a new benchmark but not free, and the
+gap is a video. These models score a video and need no reference; the export
+path renders frames. Both orbit branches in `scripts/export.sh` ask for
+`--output-format images`, and `scripts/render_nerfstudio_orbit.py` hardcodes the
+same, so nothing in this repository produces a clip for a video model to read.
+Someone has to encode one, and the encode is visible to exactly the models being
+proposed, several of which were trained to notice compression. This document
+already has one metric resolving a step that turned out to be the JPEG encoder,
+so the encode is pinned before the experiment rather than after: render the
+orbit losslessly, the PNG path the tables above use, then encode every arm of
+every comparison with one ffmpeg invocation that differs only in its input, at
+the same resolution, frame rate, pixel format, colour range and GOP length, and
+lossless where the model tolerates it. If a study wants delivery-realistic
+encoding instead, that setting is part of the stimulus and belongs in the
+protocol with its parameters written down. An encoder chosen per arm decides the
+ranking on its own.
 
 Adopting it on the strength of separation alone would repeat the mistake this
 document is about. A metric that moves when the configuration changes has shown
@@ -1016,13 +1029,21 @@ established before the metric is asked about them.
 
 The proposed experiment, in order:
 
-1. **Transfer check.** Build a ladder on one of our own scenes where the
-   ordering is not in doubt: training truncated at 2k, 5k, 10k and 30k steps, or
-   pruning at 25/50/75%, degradations large enough that anyone watching the
-   orbits agrees which is worse. Require DOVER to reproduce that order. Passing
-   shows the published 0.94 survives contact with our content and capture style;
-   it does not yet show the metric is useful on close calls. Failing kills it
-   outright, which is why this comes first and costs nothing.
+1. **Transfer check.** Build a ladder on one of our own scenes with gaps large
+   enough to be obvious: training truncated at 2k, 5k, 10k and 30k steps, or
+   pruning at 25/50/75%. The parameter order is not the perceptual order,
+   though, and this document should know better than to assume it is. Longer
+   training can regress, and pruning removes floaters as readily as it removes
+   detail, which is the direction one of the fine steps above moves in. So
+   establish the ordering the same way step 2 establishes its labels, by
+   showing the rungs blinded and pairwise and taking what the viewer says,
+   before asking DOVER anything. Then require DOVER to reproduce the order the
+   viewer gave, on the pairs the viewer called unanimously, and treat the
+   pairs they split as carrying no information either way. Passing shows the
+   published 0.94 survives contact with our content and capture style; it does
+   not yet show the metric is useful on close calls. Failing kills it outright,
+   which is why this comes first, and viewing a handful of obvious pairs is
+   what it costs.
 2. **Paired comparisons on the contested decisions.** Three comparisons would
    agree with any metric one time in eight, so the set has to be big enough for
    agreement to mean something. The cleanup threshold supplies it for free: all

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -492,10 +492,21 @@ poses, per frame, LPIPS with a 95% interval on the mean:
 | --------- | ---------------------------- | ------- | ---------------------------- | ------- |
 | 0         | 0.00000 [0.00000, 0.00000]   | inf     | 0.00000 [0.00000, 0.00000]   | inf     |
 | 0.00392   | 0.00000 [0.00000, 0.00000]   | inf     | 0.00000 [0.00000, 0.00000]   | inf     |
-| 0.01      | 0.00085 [0.00083, 0.00087]   | 51.67   | 0.00038 [0.00037, 0.00039]   | 57.62   |
-| 0.02      | 0.00186 [0.00181, 0.00191]   | 48.08   | 0.00166 [0.00163, 0.00169]   | 51.25   |
-| 0.05      | 0.00552 [0.00540, 0.00565]   | 41.95   | 0.01019 [0.00998, 0.01039]   | 41.49   |
-| 0.1       | 0.02305 [0.02248, 0.02363]   | 33.78   | 0.05711 [0.05600, 0.05823]   | 31.50   |
+| 0.01      | 0.00005 [0.00005, 0.00005]   | 61.02   | 0.00002 [0.00002, 0.00002]   | 68.01   |
+| 0.02      | 0.00030 [0.00029, 0.00031]   | 53.41   | 0.00031 [0.00030, 0.00032]   | 57.02   |
+| 0.05      | 0.00322 [0.00313, 0.00331]   | 43.20   | 0.00775 [0.00756, 0.00793]   | 42.14   |
+| 0.1       | 0.02032 [0.01979, 0.02084]   | 34.01   | 0.05406 [0.05291, 0.05520]   | 31.59   |
+
+These are lossless renders. The first attempt used the q95 JPEGs the render
+script writes by default and produced 0.00085 and 0.00038 at the 0.01 rung,
+seventeen and nineteen times the truth. Encoding the same checkpoint twice and
+comparing the copies puts the encoder's own error at 0.00795 LPIPS and 48.5 dB,
+which is nothing against a photograph, since renders sit around 22 dB from
+those, and overwhelming against another render at 61 to 68 dB. The artifacts
+mostly cancel between two nearly identical images and decorrelate as the images
+separate, so the contamination grows with the rung instead of sitting under
+everything as a constant floor: seventeen times at 0.01, six at 0.02, and still
+1.7 at 0.05. Write PNG for any render-against-render comparison.
 
 Every problem the distribution metrics had disappears. The ladder is monotone in
 both scenes. No neighbouring pair of intervals overlaps. The identity rung
@@ -511,9 +522,15 @@ question changed, and the easier question has a much better answer.
 
 What it buys is a real decision. Both scenes start from a 1M cap. Pruning at
 0.05 leaves 628k Gaussians on gaudi and 619k on r2d2, a cut of roughly 38% in
-both, and moves the delivered image by 0.0055 and 0.0102 LPIPS at 42 dB.
-Pruning at 0.1 leaves 446k and 324k, cuts of 55% and 68%, and moves it by 0.023
-and 0.057. The r2d2 cell at 0.1 is the only one that looks like a real cost. That is a defensible
+both, and moves the delivered image by 0.0032 and 0.0078 LPIPS at 42 to 43 dB.
+Pruning at 0.1 leaves 446k and 324k, cuts of 55% and 68%, and moves it by 0.020
+and 0.054 at around 32 dB. The r2d2 cell at 0.1 is the only one that looks like
+a real cost.
+
+The fine rungs land somewhere more useful than "small". At 0.01 the two renders
+differ by 61 dB on gaudi and 68 dB on r2d2, which is not a small difference so
+much as no difference at all. Whatever those rungs cost, it is not something a
+viewer could be shown. That is a defensible
 basis for setting the shipping threshold at 0.05, and it holds regardless of
 what the photographs contain or where the tourists were standing.
 

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -415,12 +415,20 @@ settles.
 
 | rung    | gaudi FID | gaudi KID x1000 | gaudi CMMD | r2d2 FID | r2d2 KID x1000 | r2d2 CMMD |
 | ------- | --------- | --------------- | ---------- | -------- | -------------- | --------- |
-| 0       | 62.68     | 16.553          | 0.4554     | 35.83    | 4.214          | 0.6907    |
-| 0.00392 | 62.68     | 16.553          | 0.4554     | 35.83    | 4.214          | 0.6907    |
-| 0.01    | 62.65     | 16.515          | 0.4563     | 35.82    | 4.209          | 0.6913    |
-| 0.02    | 62.63     | 16.460          | 0.4563     | 35.78    | 4.150          | 0.6984    |
-| 0.05    | 63.33     | 16.507          | 0.4695     | 37.29    | 4.649          | 0.7730    |
-| 0.1     | 68.10     | 18.200          | 0.5312     | 47.86    | 8.384          | 1.0172    |
+| 0       | 62.68     | 20.251          | 0.4554     | 35.83    | 7.563          | 0.6907    |
+| 0.00392 | 62.68     | 20.251          | 0.4554     | 35.83    | 7.563          | 0.6907    |
+| 0.01    | 62.65     | 20.211          | 0.4563     | 35.82    | 7.558          | 0.6913    |
+| 0.02    | 62.63     | 20.152          | 0.4563     | 35.78    | 7.497          | 0.6984    |
+| 0.05    | 63.33     | 20.193          | 0.4695     | 37.29    | 7.945          | 0.7730    |
+| 0.1     | 68.10     | 21.828          | 0.5312     | 47.86    | 11.466         | 1.0172    |
+
+Every number in that table and the next comes from one run of the estimators
+over one bootstrap index stream, so the three columns are the same resample of
+the same frames rather than three separate jobs. KID is the paired-U form
+described under "The two sets are not independent samples" below, the estimator
+this document ends up endorsing, not the standard one it rejects; the standard
+one puts the gaudi column at 16.55 and the r2d2 column at 4.21 and is compared
+against this one there.
 
 All three pass the null rung exactly, returning zero with a zero-width interval
 on the pair that renders byte-identical images.
@@ -430,47 +438,60 @@ Steps, with an interval excluding zero marked R:
 | gaudi step      | ΔFID                      | ΔKID x1000                | ΔCMMD                        |
 | --------------- | ------------------------- | ------------------------- | ---------------------------- |
 | 0 → 0.00392     | +0.000 [+0.000, +0.000]   | +0.000 [+0.000, +0.000]   | +0.0000 [+0.0000, +0.0000]   |
-| 0.00392 → 0.01  | -0.028 [-0.088, +0.030]   | -0.038 [-0.065, +0.010]   | +0.0009 [-0.0002, +0.0023]   |
-| 0.01 → 0.02     | -0.024 [-0.172, +0.100]   | -0.055 [-0.198, +0.035]   | -0.0000 [-0.0023, +0.0023]   |
-| 0.02 → 0.05     | +0.702 [+0.253, +1.339] R | +0.047 [-0.316, +0.762]   | +0.0132 [+0.0099, +0.0184] R |
-| 0.05 → 0.1      | +4.772 [+4.105, +6.951] R | +1.694 [+0.929, +3.961]   | +0.0618 [+0.0470, +0.0862] R |
+| 0.00392 → 0.01  | -0.028 [-0.097, +0.027]   | -0.039 [-0.072, -0.006] R | +0.0009 [-0.0002, +0.0022]   |
+| 0.01 → 0.02     | -0.024 [-0.169, +0.107]   | -0.059 [-0.203, +0.048]   | -0.0000 [-0.0024, +0.0022]   |
+| 0.02 → 0.05     | +0.702 [+0.221, +1.409]   | +0.041 [-0.318, +0.793]   | +0.0132 [+0.0099, +0.0179] R |
+| 0.05 → 0.1      | +4.772 [+3.964, +6.823] R | +1.634 [+0.634, +3.528]   | +0.0618 [+0.0465, +0.0883] R |
 
 | r2d2 step       | ΔFID                         | ΔKID x1000                | ΔCMMD                        |
 | --------------- | ---------------------------- | ------------------------- | ---------------------------- |
 | 0 → 0.00392     | +0.000 [+0.000, +0.000]      | +0.000 [+0.000, +0.000]   | +0.0000 [+0.0000, +0.0000]   |
-| 0.00392 → 0.01  | -0.001 [-0.013, +0.012]      | -0.005 [-0.017, +0.008]   | +0.0006 [-0.0007, +0.0018]   |
-| 0.01 → 0.02     | -0.049 [-0.116, +0.009]      | -0.059 [-0.118, -0.024]   | +0.0071 [+0.0048, +0.0096] R |
-| 0.02 → 0.05     | +1.511 [+1.054, +2.246] R    | +0.499 [+0.135, +1.081]   | +0.0746 [+0.0624, +0.0876] R |
-| 0.05 → 0.1      | +10.577 [+9.925, +14.690] R  | +3.735 [+2.937, +6.391] R | +0.2442 [+0.2039, +0.2937] R |
+| 0.00392 → 0.01  | -0.001 [-0.012, +0.012]      | -0.005 [-0.018, +0.007]   | +0.0006 [-0.0007, +0.0019]   |
+| 0.01 → 0.02     | -0.049 [-0.119, +0.012]      | -0.061 [-0.125, -0.024]   | +0.0071 [+0.0045, +0.0095] R |
+| 0.02 → 0.05     | +1.511 [+1.049, +2.325] R    | +0.448 [+0.029, +0.911]   | +0.0746 [+0.0633, +0.0888] R |
+| 0.05 → 0.1      | +10.577 [+9.860, +14.639] R  | +3.521 [+2.503, +6.111] R | +0.2442 [+0.2020, +0.2936] R |
 
-The coarse end belongs to FID and CMMD. Both resolve 0.02 to 0.05 and 0.05 to
-0.1 on both scenes, and agree on direction throughout. KID resolves one of those
-four, r2d2's 0.05 to 0.1, and the intervals shown carry the R only where the
-percentile and basic constructions agree, which costs KID two of the three it
-had under the percentile alone. The weakest of the resolved cases is FID on
-gaudi's 0.02 to 0.05 step, where the interval's near end still sits a third of
-the way to the estimate.
+The coarse end belongs to CMMD and FID. CMMD resolves all four coarse steps,
+FID three of them, and the two agree on direction throughout. KID resolves one,
+r2d2's 0.05 to 0.1. An interval carries the R only where the percentile and the
+basic construction agree, and the step FID loses that way is gaudi's 0.02 to
+0.05: the percentile interval is [+0.221, +1.409] on an estimate of +0.702, and
+reflecting it about the estimate gives [-0.006, +1.182]. It crosses zero by less
+than a hundredth of the step. At 400 replicates it did not cross at all; four
+thousand put the upper tail further out and the reflected lower end followed it
+down through zero, which is what happens to a verdict that was never far from
+the line.
 
-The fine end resolves once, for CMMD, on r2d2's 0.01 to 0.02 step at +0.0071
-with [+0.0048, +0.0096]. FID spans zero there, and on the other three fine steps
-every metric does.
+Two fine steps resolve, on different scenes and pointing opposite ways. CMMD
+takes r2d2's 0.01 to 0.02 at +0.0071 with [+0.0045, +0.0095], the pruning
+scoring worse. KID takes gaudi's 0.00392 to 0.01 at -0.039 with
+[-0.072, -0.006], the pruning scoring better, and that is the weakest resolution
+in either table: the near end of the interval sits at a sixth of the estimate,
+and the block-length check below is unkind to it. CMMD puts that same step at
++0.0009, the other way, and does not resolve it. On the remaining fine steps
+every metric spans zero.
 
-That step used to read as a contradiction. KID gives -0.059 on the same images
-and the same frames, and its interval excluded zero too, so two estimators were
-resolving one step in opposite directions. The disagreement was never a fact
-about the images. It came from the paired cross terms below, and once those are
-removed KID's interval covers zero and only CMMD is left saying anything. What
-survives is a weaker statement worth keeping: a polynomial-kernel distance on
-Inception features and an RBF distance on CLIP features can move in opposite
-directions on the same change without either being wrong, so at most one of
-them tracks any single notion of quality, and this data cannot say which, or
-whether either does.
+The disagreement on r2d2's 0.01 to 0.02 step used to be sharper. KID gives
+-0.061 there on the same images and the same frames, and under the standard
+estimator its interval excluded zero under both constructions, so two estimators
+were resolving one step in opposite directions. That was never a fact about the
+images. It came from the paired cross terms below, and once those are removed
+the basic interval reads [-0.098, +0.003] and only CMMD is left saying anything.
+What survives, on both that step and gaudi's fine one, is a weaker statement
+worth keeping: a polynomial-kernel distance on Inception features and an RBF
+distance on CLIP features can move in opposite directions on the same change
+without either being wrong, so at most one of them tracks any single notion of
+quality, and this data cannot say which, or whether either does.
 
 An earlier version of this section had FID resolving gaudi's 0.00392 to 0.01
 step as an improvement, and I read that as the metric misbehaving. It was the
 JPEG encoder, and it vanished when the renders were written losslessly. Worth
 recording, because a resolved interval on an artifact is the exact failure this
-document is about, produced while writing it.
+document is about, produced while writing it. KID now resolves that same step in
+that same direction on the lossless renders, which is not the same finding: the
+images it is separating differ by the pruning and by nothing else. Whether a
+distance of 0.039 in KID units is worth separating is the question no bound
+here settles.
 
 #### A flaw in the standard KID protocol
 
@@ -503,19 +524,21 @@ is enormous for KID. Gaudi's ladder moves from 16.55 to 20.25 and r2d2's from
 render and someone else's pose. CMMD's unbiased check moves about 2%, from
 0.4394 to 0.4490 and from 0.6751 to 0.6861.
 
-On the differences it is small and uneven. Every CMMD step moves by under 1% and
-not one classification changes, under either interval construction. KID's move
-by up to 10%: r2d2's 0.02 to 0.05 goes from +0.499 to +0.448 and its 0.05 to 0.1
-from +3.735 to +3.521. The correction also shrinks as the rungs coarsen instead
-of holding constant, which is the configuration dependence showing up directly.
+On the differences it is small and uneven. Every CMMD step moves by under 1% of
+itself and not one classification changes, under either interval construction;
+the one step that is zero to four decimals moves by 0.00002 in absolute terms,
+where a percentage means nothing. KID's move by up to 12%: r2d2's 0.02 to 0.05
+goes from +0.499 to +0.448 and its 0.05 to 0.1 from +3.735 to +3.521. The
+correction to the levels also shrinks as the rungs coarsen instead of holding
+constant, which is the configuration dependence showing up directly.
 
-One verdict does not survive it. KID's r2d2 0.01 to 0.02 step, the one place the
-fine end resolved for it, reads [-0.096, -0.001] with the paired terms in and
-[-0.097, +0.005] with them out. That was the disagreement with CMMD, and it was
-an artifact of the estimator. A step is marked R above only when it excludes
-zero under both interval constructions and both treatments of the cross terms.
-That leaves KID resolving one of the eight steps, r2d2's 0.05 to 0.1, and leaves
-the fine end to CMMD alone.
+It swaps which fine step KID resolves. With the paired terms in, r2d2's 0.01 to
+0.02 excludes zero under both constructions and gaudi's 0.00392 to 0.01 does
+not; with them out it is the other way round. The r2d2 step is the one that used
+to disagree with CMMD, and the disagreement was an artifact of the estimator.
+The tables above are the paired-U column throughout, which leaves KID resolving
+two of the eight steps, r2d2's 0.05 to 0.1 and gaudi's 0.00392 to 0.01, the
+second of them barely.
 
 FID is untouched. It uses each set's own mean and covariance and never forms a
 cross-set kernel, so there is no paired term in it to remove.
@@ -538,36 +561,35 @@ mean over the replicates is a different quantity for a nonlinear statistic,
 estimating the resampling expectation rather than the difference that was
 measured, and it would make the point estimate depend on the replicate count and
 the seed. The interval is the 2.5th and 97.5th percentile of the replicate
-differences. R marks a step that excludes zero under every construction and
-estimator variant the sections above try, which for the set-level metrics means
-both interval constructions and both treatments of the paired cross terms. The
-set-level
-tables use 400 replicates, the per-frame LPIPS ones 2000, and the walkthrough
-comparison quoted earlier 20000. Every generator is seeded at 0, and the
-set-level runs draw the whole ladder from one of them in sequence, so those
-intervals are reproducible as a set rather than one step at a time. Their
-endpoints move in the last quoted digit between generators in any case. FID uses
-the low-rank Frechet identity described below, KID the unbiased estimator on the
-full set with no subset averaging, and CMMD the V-statistic accumulated in
-float64.
+differences. R marks a step that excludes zero under both interval
+constructions. The set-level tables use 4000 replicates, the per-frame LPIPS
+ones 2000, and the walkthrough comparison quoted earlier 20000. The set-level
+run seeds one generator per step rather than one per run, so the Inception pass
+and the CLIP pass, which need different environments and cannot share a process,
+still resample the same frames in the same order and the three columns of a row
+are one resample rather than three. FID uses the low-rank Frechet identity
+described below, KID the unbiased estimator on the full set with no subset
+averaging and with the paired cross terms dropped, and CMMD the V-statistic
+accumulated in float64.
 
-Which point estimate gets reported is not a formality here. On r2d2's 0.05 to
-0.1 step the replicate mean sits at 12.00 FID against 10.58 observed and at 4.40
-KID against 3.74, so the percentile interval is dragged along with it and the
-observed value lands near its lower end rather than in the middle. CMMD moves by
-under three percent on the same step.
+Which point estimate gets reported is not a formality here. The replicates of a
+nonlinear statistic do not centre on the observed value, and the percentile
+interval is dragged with them: on r2d2's 0.05 to 0.1 step FID reads +10.577 with
+[+9.860, +14.639], which puts the observed value 0.72 above the lower end and
+4.06 below the upper, and KID reads +3.521 with [+2.503, +6.111], 1.02 against
+2.59. CMMD on the same step is nearly symmetric, 0.042 against 0.049.
 
 That shift belongs to the resampling rather than to the sampling uncertainty,
 and a percentile interval carries it into the verdict. The basic interval
 removes it by reflecting the replicates through the observed value, and the two
-constructions disagree on three steps, all of them KID: gaudi's 0.05 to 0.1 and
-r2d2's 0.02 to 0.05 lose their exclusion of zero, gaudi's 0.00392 to 0.01 gains
-one. FID and CMMD keep every classification under both. So R marks a step whose
-interval excludes zero under both constructions, and the three that disagree are
-left unresolved. Even that is generous in one place: r2d2's 0.01 to 0.02 clears
-under the basic interval by 0.00013 on a step of -0.059. The LPIPS ladder needs
-none of this, since the bootstrap expectation of a sample mean is the sample
-mean and there is no shift to remove.
+constructions disagree on four steps. Three are KID, which loses its exclusion
+of zero on gaudi's 0.05 to 0.1 and on both of r2d2's fine and coarse middle
+steps; one is FID on gaudi's 0.02 to 0.05, where the reflected interval clears
+zero by 0.006 on a step of +0.702. CMMD keeps every classification under both.
+So R marks a step whose interval excludes zero under both constructions, and the
+four that disagree are left unresolved. The LPIPS ladder needs none of this,
+since the bootstrap expectation of a sample mean is the sample mean and there is
+no shift to remove.
 
 How much it costs splits the metrics in two, and the split is the useful part of
 the check. Interval width at block length 20 over width at block length 1:
@@ -575,43 +597,49 @@ the check. Interval width at block length 20 over width at block length 1:
 | statistic                         | ratio        |
 | --------------------------------- | ------------ |
 | LPIPS, a mean of per-frame values | 3.0 to 3.8   |
-| FID, KID and CMMD, set-level      | 0.89 to 1.72 |
+| FID, KID and CMMD, set-level      | 0.80 to 1.87 |
 
 The three set-level metrics are not separable from each other on this: FID runs
-0.89 to 1.61, KID 1.06 to 1.67, CMMD 0.91 to 1.72, all overlapping. What
-separates them from LPIPS is that a mean of per-frame values is exactly what
-correlated neighbours inflate, while a statistic computed from the whole
-resampled set carries less of it. So block resampling costs the
-export-referenced LPIPS ladder below a great deal of width and this section
-almost none.
+0.94 to 1.56, KID 0.80 to 1.75, CMMD 0.81 to 1.87, all overlapping, and each of
+them goes below 1 on some step, meaning the block resample came out narrower
+than the i.i.d. one there. What separates them from LPIPS is that a mean of
+per-frame values is exactly what correlated neighbours inflate, while a
+statistic computed from the whole resampled set carries less of it. So block
+resampling costs the export-referenced LPIPS ladder below a great deal of width
+and this section almost none.
 
 Width is not the whole story, and stopping at 20 was a choice, so the set-level
-metrics got the same sweep out to 100. Their widths peak between 5 and 40
-depending on the step and shrink from 60 on, the same collapse the LPIPS ladder
-shows, so a long block is not a conservative block here either. Out to 40 no
-verdict moves with the block length. Under the percentile construction the 0.02
-to 0.05 and 0.05 to 0.1 steps stay resolved for every metric on both scenes
-except KID on gaudi's 0.02 to 0.05, which stays unresolved, and r2d2's 0.01 to
-0.02 stays resolved for CMMD at every length tried, and for KID at every length
-until the paired cross terms come out.
+metrics got the same sweep out to 100, on the estimators the tables report.
+Their widths peak anywhere from 1 to 40 depending on the step and every one of
+them is narrower at 100 than at its own peak, the same collapse the LPIPS ladder
+shows, so a long block is not a conservative block here either.
 
-Crossing that sweep with the interval construction sorts the three metrics:
-CMMD holds every coarse verdict under both constructions at every block length,
-FID holds all of them except gaudi's 0.02 to 0.05 at block lengths 5 and 10,
-and KID's coarse verdicts move with the block length, the construction, or
-both. Its gaudi 0.05 to 0.1 step, for one, excludes zero under the basic
-interval at block length 1 and from 60 up, and not between.
+Crossing that sweep with the interval construction sorts the three metrics. CMMD
+holds every coarse verdict under both constructions at every block length, and
+holds r2d2's fine 0.01 to 0.02 step the same way. FID holds its coarse verdicts
+except gaudi's 0.02 to 0.05, which clears zero under both constructions at block
+length 1 and from 30 up and fails the basic interval at 5, 10 and 20; the tables
+report 20, which is why it carries no R there. KID's verdicts move with the
+block length, the construction or both on every step except r2d2's coarsest. Its
+gaudi 0.05 to 0.1 step, for one, excludes zero under the basic interval at block
+length 1 and from 60 up, and not between.
 
-Past 40 the collapse starts manufacturing resolutions instead: r2d2's 0.01 to
-0.02 turns resolved for FID at 60, gaudi's 0.01 to 0.02 for KID at 100.
+Two cases sit on the line rather than move around. r2d2's 0.01 to 0.02 KID step
+clears zero under the basic interval by 0.00014 at 2000 replicates and misses it
+by 0.0026 at 4000, same data and same block length, so the tables' unresolved
+verdict is the better tail estimate rather than a different finding. Gaudi's
+0.00392 to 0.01 KID step, the one the tables do mark, resolves under both
+constructions at every block length from 10 up and at none below: the i.i.d.
+bootstrap puts its upper end within 0.00001 of zero. Its interval also narrows
+monotonically as the blocks lengthen, from 0.081 at length 1 to 0.029 at 100, so
+that resolution is one the resampling scheme grants rather than one it survives.
+It is the weakest R in the document and nothing rests on it.
 
-The rest of the fine end is worse than the tables make it look. Gaudi's 0.00392
-to 0.01 KID interval has an endpoint sitting on zero and changes verdict at
-almost every block length tried: resolved at 1, 10, 30 and everything from 60
-up, unresolved at 5, 20 and 40. That step is not measuring anything. The coarse
-conclusions for FID and CMMD survive both the block length and the construction,
-KID's do not, and the fine ones apart from r2d2's 0.01 to 0.02 were never
-conclusions.
+Past 40 the collapse manufactures resolutions outright: r2d2's 0.01 to 0.02
+turns resolved for FID at 60, gaudi's 0.00392 to 0.01 for CMMD at 80 and for FID
+at 100, and gaudi's 0.01 to 0.02 for KID at 100. The coarse conclusions for CMMD
+survive both the block length and the construction, FID's survive everywhere
+except the one step and band noted above, and KID's do not survive at all.
 
 It does not overturn the LPIPS ladder, and the widths do not run away either.
 At 20 they were still climbing, 16 to 22% over block length 10, which left the
@@ -665,8 +693,8 @@ does not move. The excess is 0.0160 on gaudi and 0.0156 on r2d2, the same to
 four decimals across all six rungs, and the configuration-dependent factor
 varies only in the fifth decimal. Recomputing every step with the unbiased
 estimator shifts none of them by more than 0.00015 and leaves every
-classification standing: r2d2's 0.01 to 0.02 step reads +0.0071 with
-[+0.0048, +0.0096] biased and +0.0071 with [+0.0047, +0.0095] unbiased.
+classification standing: r2d2's 0.01 to 0.02 step reads +0.00711 with
+[+0.00453, +0.00948] biased and +0.00713 with [+0.00454, +0.00950] unbiased.
 
 Checking that turned up a fourth thing, which has nothing to do with either
 objection. CMMD is 1000 times the difference of three kernel means that all sit
@@ -682,33 +710,59 @@ three decimals of number and one of rounding.
 
 #### How much of each is the sample count
 
-Each estimator on the unpruned run, at four frame counts:
+A first version of this table took one random subset of frames per count, which
+changed the count and the poses in it at the same time and could not say which
+one moved the number. Two hundred subsets per count instead. The mean over them
+is what the count does with the choice of poses averaged out, and the spread
+over them is what the choice of poses alone is worth at a fixed count. Each
+estimator on the unpruned run, mean and standard deviation over the draws:
 
-| frames | gaudi FID | gaudi KID | gaudi CMMD | frames | r2d2 FID | r2d2 KID | r2d2 CMMD |
-| ------ | --------- | --------- | ---------- | ------ | -------- | -------- | --------- |
-| 28     | 75.46     | 1.528     | 0.4377     | 36     | 43.44    | -6.431   | 0.6206    |
-| 56     | 70.06     | 14.060    | 0.4842     | 73     | 38.58    | 1.164    | 0.6754    |
-| 84     | 67.34     | 14.559    | 0.4561     | 110    | 37.60    | 3.887    | 0.7154    |
-| 112    | 62.68     | 16.553    | 0.4554     | 147    | 35.83    | 4.214    | 0.6907    |
+| frames | gaudi FID    | gaudi KID    | gaudi CMMD      |
+| ------ | ------------ | ------------ | --------------- |
+| 28     | 73.84 ± 3.83 | 19.81 ± 2.60 | 0.4740 ± 0.0278 |
+| 56     | 68.98 ± 2.08 | 20.31 ± 1.46 | 0.4629 ± 0.0194 |
+| 84     | 65.55 ± 1.06 | 20.27 ± 0.85 | 0.4584 ± 0.0103 |
+| 112    | 62.68        | 20.25        | 0.4554          |
 
-FID falls monotonically as frames are added in both scenes, which is the bias
-Chong and Forsyth describe. The drift is 12.8 points on gaudi against a ladder
-whose whole range is 5.4, so the number cannot be read on its own and two
-configurations evaluated at different frame counts cannot be compared at all.
-The steps above survive because the shared bootstrap cancels the part of that
-bias the two runs have in common. How much that is stays unmeasured. The null
-rung shows the cancellation is exact when the two configurations are identical,
-which is the easy case; the bias depends on the feature distribution, and two
-configurations that differ do not have to share all of it.
+| frames | r2d2 FID     | r2d2 KID    | r2d2 CMMD       |
+| ------ | ------------ | ----------- | --------------- |
+| 36     | 45.08 ± 2.39 | 7.49 ± 0.99 | 0.7067 ± 0.0460 |
+| 73     | 40.98 ± 1.20 | 7.59 ± 0.48 | 0.6964 ± 0.0258 |
+| 110    | 38.04 ± 0.65 | 7.58 ± 0.31 | 0.6925 ± 0.0142 |
+| 147    | 35.83        | 7.56        | 0.6907          |
 
-KID is worse in a different way. A single draw at 36 frames puts the r2d2 run at
--6.4, a negative squared distance, which an unbiased estimator is entitled to
-produce and which supports no ordering whatsoever. Unbiased in expectation is
-not the same as usable from one draw at this size. CMMD wanders least in
-relative terms but still moves more between 28 and 56 frames than the entire
-0.02 to 0.05 step it is being asked to detect. Its rows below the full frame
-count are float32 and carry the 0.0002 noted above, which is two orders of
-magnitude under the drift being discussed.
+The last row of each is the whole set, so it has no spread. KID here is the
+full-set paired-U estimator and CMMD is accumulated in float64, matching the
+tables above rather than the protocols this document has since rejected.
+
+FID's mean falls with every frame added, on both scenes, which is the bias
+Chong and Forsyth describe and not an accident of which poses were drawn: 11.2
+points on gaudi and 9.3 on r2d2, against ladders whose whole range is 5.5 and
+12.1. The fall is three to four times the pose scatter at the smallest count
+and far more than that against the scatter of the mean, so the number cannot be
+read on its own and two configurations evaluated at different frame counts
+cannot be compared at all. The steps above survive because the shared bootstrap
+cancels the part of that bias the two runs have in common. How much that is
+stays unmeasured. The null rung shows the cancellation is exact when the two
+configurations are identical, which is the easy case; the bias depends on the
+feature distribution, and two configurations that differ do not have to share
+all of it.
+
+KID's problem is the other one. Its mean barely moves with the count, which is
+what an unbiased estimator is supposed to do, but the spread at the smallest
+count is 2.60 on gaudi against a KID ladder spanning 1.68 end to end. One draw
+at that size says nothing about the configuration; it says which poses were
+drawn. An earlier version of this table read -6.4 for r2d2 at 36 frames and I
+took that as a fact about the sample size. It was the subset-averaging protocol
+rejected above, applied to one draw: under the full-set estimator, 200 draws at
+36 frames put the 5th percentile at 6.0 and none of them went negative. An
+unbiased estimator of a squared distance may still return a negative number, and
+nothing here says this one will not, only that it did not.
+
+CMMD carries a count bias of its own, smaller than FID's in relative terms and
+not negligible against what it is being asked to detect. Its mean falls
+0.0186 on gaudi between 28 frames and 112, monotonically, and gaudi's 0.02 to
+0.05 step, one of the two coarse steps it resolves there, is 0.0132.
 
 Three limits apply to all of the above. These are training views, which the
 model was fit to, so nothing here establishes how these transforms behave on
@@ -731,20 +785,20 @@ sensitivity looks like. Calling it an error would need an equivalence bound
 declared in advance and an interval that fits inside it, which is the same thing
 this document demands before anyone calls PSNR blind. No such bound exists here.
 
-So the fine end ranks nobody. FID and KID resolve nothing there, CMMD resolves
-one step, and which of those is the right behaviour depends on a threshold
-nobody has set.
+So the fine end ranks nobody. FID resolves nothing there, CMMD resolves one
+step and KID another, in opposite directions on different scenes, and which of
+those is the right behaviour depends on a threshold nobody has set.
 
 What does separate them needs no labels, because it is about the estimators
 rather than the images. Two things, and the first version of one of them was
 wrong.
 
-FID's absolute level falls 12.8 points between 28 and 112 frames, more than
-twice the range of the whole ladder, so it cannot be read as a number and two
-configurations scored at different frame counts cannot be compared at all. The
-paired steps survive because the shared bootstrap cancels the part of that drift
-the two runs have in common, with the caveat above on how much that is. Nothing
-rescues the level.
+FID's absolute level falls 11.2 points between 28 and 112 frames with the
+choice of poses averaged out, twice the range of the whole ladder, so it cannot
+be read as a number and two configurations scored at different frame counts
+cannot be compared at all. The paired steps survive because the shared bootstrap
+cancels the part of that drift the two runs have in common, with the caveat
+above on how much that is. Nothing rescues the level.
 
 The second is discriminability under matched samples. Each metric's own
 bootstrap supplies its sampling deviation, on the same frames under the same
@@ -754,31 +808,31 @@ differ:
 
 | step             | FID  | KID  | CMMD  |
 | ---------------- | ---- | ---- | ----- |
-| gaudi 0.02→0.05  | 2.53 | 0.17 | 6.10  |
-| gaudi 0.05→0.1   | 6.57 | 2.19 | 6.18  |
-| r2d2 0.02→0.05   | 4.97 | 2.07 | 11.59 |
-| r2d2 0.05→0.1    | 8.70 | 4.24 | 10.66 |
+| gaudi 0.02→0.05  | 2.32 | 0.15 | 6.44  |
+| gaudi 0.05→0.1   | 6.54 | 2.21 | 5.79  |
+| r2d2 0.02→0.05   | 4.64 | 1.99 | 11.43 |
+| r2d2 0.05→0.1    | 8.68 | 3.83 | 10.45 |
 
 CMMD leads in three of the four and KID trails in all four, while FID takes the
-largest step on gaudi's coarsest. That is the comparison this conclusion
-needed. An earlier version rested it on KID returning -6.4 at 36 frames, which
-does not support anything: a negative value is exactly what an unbiased
-U-statistic is entitled to produce, it bars reading that point estimate as an
-absolute distance, and it leaves untouched the paired differences the tables
-above are built from. CMMD's estimator is the biased V-statistic and nonnegative
-by construction, so never going negative is a property of its formula rather
-than evidence of stability.
+largest step on gaudi's coarsest. That is the comparison this conclusion needed.
+An earlier version rested it on KID returning -6.4 at 36 frames, which supports
+nothing twice over: that value came from the subset protocol rejected above, and
+a negative value is in any case what an unbiased U-statistic is entitled to
+produce, which bars reading the point estimate as an absolute distance and
+leaves the paired differences untouched. CMMD's estimator is the biased
+V-statistic and nonnegative by construction, so never going negative is a
+property of its formula rather than evidence of stability.
 
 The fine steps are left out of that table on purpose. A higher ratio there would
 mean only that an estimator separates images that barely differ, and whether
 that is a virtue is the question no bound has settled.
 
-FID and CMMD resolve both coarse steps on both scenes and agree on direction,
-which is the regime where the choice between those two stops mattering. KID does
-not join them. It fails gaudi's 0.02 to 0.05 outright, at +0.047 with
-[-0.316, +0.762] and unresolved at every block length tried, and loses gaudi's
-0.05 to 0.1 and r2d2's 0.02 to 0.05 once the interval stops carrying its own
-resampling bias.
+CMMD resolves both coarse steps on both scenes, FID three of the four, and the
+two agree on direction, which is the regime where the choice between them stops
+mattering. KID does not join them. It fails gaudi's 0.02 to 0.05 outright, at
++0.041 with [-0.318, +0.793] and unresolved at every block length tried, and
+loses gaudi's 0.05 to 0.1 and r2d2's 0.02 to 0.05 once the interval stops
+carrying its own resampling bias.
 
 The larger conclusion is that this line of attack was aimed at a problem we do
 not have. Set-level metrics earn their keep when nothing corresponds between the

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -728,9 +728,9 @@ sensitivity looks like. Calling it an error would need an equivalence bound
 declared in advance and an interval that fits inside it, which is the same thing
 this document demands before anyone calls PSNR blind. No such bound exists here.
 
-So the fine end ranks nobody. FID resolves nothing there, KID and CMMD resolve
-the same single step and disagree about its sign, and which behaviour is correct
-depends on a threshold nobody has set.
+So the fine end ranks nobody. FID and KID resolve nothing there, CMMD resolves
+one step, and which of those is the right behaviour depends on a threshold
+nobody has set.
 
 What does separate them needs no labels, because it is about the estimators
 rather than the images. Two things, and the first version of one of them was

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -439,7 +439,7 @@ Steps, with an interval excluding zero marked R:
 | --------------- | ---------------------------- | ------------------------- | ---------------------------- |
 | 0 → 0.00392     | +0.000 [+0.000, +0.000]      | +0.000 [+0.000, +0.000]   | +0.0000 [+0.0000, +0.0000]   |
 | 0.00392 → 0.01  | -0.001 [-0.013, +0.012]      | -0.005 [-0.017, +0.008]   | +0.0006 [-0.0007, +0.0018]   |
-| 0.01 → 0.02     | -0.049 [-0.116, +0.009]      | -0.059 [-0.118, -0.024] R | +0.0071 [+0.0048, +0.0096] R |
+| 0.01 → 0.02     | -0.049 [-0.116, +0.009]      | -0.059 [-0.118, -0.024]   | +0.0071 [+0.0048, +0.0096] R |
 | 0.02 → 0.05     | +1.511 [+1.054, +2.246] R    | +0.499 [+0.135, +1.081]   | +0.0746 [+0.0624, +0.0876] R |
 | 0.05 → 0.1      | +10.577 [+9.925, +14.690] R  | +3.735 [+2.937, +6.391] R | +0.2442 [+0.2039, +0.2937] R |
 
@@ -451,17 +451,20 @@ had under the percentile alone. The weakest of the resolved cases is FID on
 gaudi's 0.02 to 0.05 step, where the interval's near end still sits a third of
 the way to the estimate.
 
-The fine end resolves once, and the one time it does the metrics disagree about
-which way. On r2d2's 0.01 to 0.02 step KID reports -0.059 with an interval of
-[-0.118, -0.024] while CMMD reports +0.0071 with [+0.0048, +0.0096]: same
-images, same frames, both excluding zero, opposite signs. FID spans zero there,
-and on the other three fine steps all three metrics do. That is less damning
-than it first looks. KID measures a polynomial-kernel distance between Inception
-features and CMMD an RBF distance between CLIP features, so a change in the
-images can genuinely shorten one and lengthen the other. Nothing is being
-contradicted. What it does mean is that at most one of them can be tracking any
-single underlying notion of quality, and this data cannot say which, or whether
-either does.
+The fine end resolves once, for CMMD, on r2d2's 0.01 to 0.02 step at +0.0071
+with [+0.0048, +0.0096]. FID spans zero there, and on the other three fine steps
+every metric does.
+
+That step used to read as a contradiction. KID gives -0.059 on the same images
+and the same frames, and its interval excluded zero too, so two estimators were
+resolving one step in opposite directions. The disagreement was never a fact
+about the images. It came from the paired cross terms below, and once those are
+removed KID's interval covers zero and only CMMD is left saying anything. What
+survives is a weaker statement worth keeping: a polynomial-kernel distance on
+Inception features and an RBF distance on CLIP features can move in opposite
+directions on the same change without either being wrong, so at most one of
+them tracks any single notion of quality, and this data cannot say which, or
+whether either does.
 
 An earlier version of this section had FID resolving gaudi's 0.00392 to 0.01
 step as an improvement, and I read that as the metric misbehaving. It was the
@@ -484,6 +487,39 @@ uncertainty left. Every KID number above is computed that way, and anyone
 comparing two configurations with KID should do the same, or at minimum share
 the subset draws between them.
 
+#### The two sets are not independent samples
+
+KID and the unbiased CMMD check both estimate a distance between two
+distributions, and both are unbiased for it when the two sets are independent
+samples. These sets are not. Render i and photograph i are the same camera pose,
+so k(render_i, photo_i) is not a draw from the product of the marginals, and the
+two-sample estimator keeps all n of those terms inside a cross sum of n squared.
+The resulting bias is O(1/n) and depends on the configuration being scored,
+which is the combination a difference between configurations cannot cancel.
+
+Dropping the paired terms costs one line and settles the size. On the levels it
+is enormous for KID. Gaudi's ladder moves from 16.55 to 20.25 and r2d2's from
+4.21 to 7.56, because a render and its own photograph are far more alike than a
+render and someone else's pose. CMMD's unbiased check moves about 2%, from
+0.4394 to 0.4490 and from 0.6751 to 0.6861.
+
+On the differences it is small and uneven. Every CMMD step moves by under 1% and
+not one classification changes, under either interval construction. KID's move
+by up to 10%: r2d2's 0.02 to 0.05 goes from +0.499 to +0.448 and its 0.05 to 0.1
+from +3.735 to +3.521. The correction also shrinks as the rungs coarsen instead
+of holding constant, which is the configuration dependence showing up directly.
+
+One verdict does not survive it. KID's r2d2 0.01 to 0.02 step, the one place the
+fine end resolved for it, reads [-0.096, -0.001] with the paired terms in and
+[-0.097, +0.005] with them out. That was the disagreement with CMMD, and it was
+an artifact of the estimator. A step is marked R above only when it excludes
+zero under both interval constructions and both treatments of the cross terms.
+That leaves KID resolving one of the eight steps, r2d2's 0.05 to 0.1, and leaves
+the fine end to CMMD alone.
+
+FID is untouched. It uses each set's own mean and covariance and never forms a
+cross-set kernel, so there is no paired term in it to remove.
+
 #### What the intervals assume
 
 Every interval above comes from a moving-block bootstrap with a block length of
@@ -502,7 +538,10 @@ mean over the replicates is a different quantity for a nonlinear statistic,
 estimating the resampling expectation rather than the difference that was
 measured, and it would make the point estimate depend on the replicate count and
 the seed. The interval is the 2.5th and 97.5th percentile of the replicate
-differences, and R marks an interval that does not contain zero. The set-level
+differences. R marks a step that excludes zero under every construction and
+estimator variant the sections above try, which for the set-level metrics means
+both interval constructions and both treatments of the paired cross terms. The
+set-level
 tables use 400 replicates, the per-frame LPIPS ones 2000, and the walkthrough
 comparison quoted earlier 20000. Every generator is seeded at 0, and the
 set-level runs draw the whole ladder from one of them in sequence, so those
@@ -553,11 +592,13 @@ shows, so a long block is not a conservative block here either. Out to 40 no
 verdict moves with the block length. Under the percentile construction the 0.02
 to 0.05 and 0.05 to 0.1 steps stay resolved for every metric on both scenes
 except KID on gaudi's 0.02 to 0.05, which stays unresolved, and r2d2's 0.01 to
-0.02 stays resolved for KID and CMMD in opposite directions at every length
-tried. Crossing that sweep with the interval construction sorts the three
-metrics: CMMD holds every coarse verdict under both constructions at every block
-length, FID holds all of them except gaudi's 0.02 to 0.05 at block lengths 5 and
-10, and KID's coarse verdicts move with the block length, the construction, or
+0.02 stays resolved for CMMD at every length tried, and for KID at every length
+until the paired cross terms come out.
+
+Crossing that sweep with the interval construction sorts the three metrics:
+CMMD holds every coarse verdict under both constructions at every block length,
+FID holds all of them except gaudi's 0.02 to 0.05 at block lengths 5 and 10,
+and KID's coarse verdicts move with the block length, the construction, or
 both. Its gaudi 0.05 to 0.1 step, for one, excludes zero under the basic
 interval at block length 1 and from 60 up, and not between.
 
@@ -811,8 +852,8 @@ at the block length where the resampling is widest, 2.7 under a Newey-West
 variance at a bandwidth of 40, and no pair comes closer at any block length from
 1 to 100. Closing the tightest of those gaps takes a factor of 2.6 in width,
 against the tenth that separates the three treatments. CMMD does better than the
-other two at the fine end: it orders both ladders correctly, and it resolves
-r2d2's 0.01 to 0.02 step, which KID also resolves in the opposite direction.
+other two at the fine end: it orders both ladders correctly, and it is the only
+one of the three that resolves r2d2's 0.01 to 0.02 step.
 
 The reason is not that LPIPS is a better metric than CMMD. It is that the
 comparison is paired at the level of individual frames against an exact

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -945,15 +945,23 @@ The proposed experiment, in order:
 
    Show every pair three times, separated. The repeats are not padding: they
    measure how often the rater agrees with themselves, which caps how much
-   agreement any metric could show. Two showings cannot establish that. A
-   rater guessing on a pair they see no difference in still repeats the same
-   answer about a third of the time when there are three responses to choose
-   from, and every one of those accidents would enter the next step as a
-   label. Requiring all three showings to agree drops that floor to one in
-   nine, and what it filters out is concentrated in the close pairs, which are
-   the ones the exercise is about. Report the raw agreement rate next to the
-   floor. A rate near it on the close pairs says the rater cannot separate
-   them at all, which answers the question without a metric and means no
+   agreement any metric could show. Two showings cannot establish that. A rater
+   guessing on a pair they see no difference in repeats the same answer often
+   enough that those accidents would enter the next step as labels, and
+   requiring all three showings to agree is what thins them out, concentrated
+   in the close pairs, which are the ones the exercise is about.
+
+   How far it thins them is not a constant. One in nine is the floor for a
+   rater who splits the three responses evenly and answers each showing
+   independently of the last, and no one does the first. Estimate it from the
+   rater's own marginal frequencies instead, as the chance that three
+   independent draws from those frequencies agree, which is p_left cubed plus
+   p_right cubed plus p_none cubed. A rater who answers "no difference" most of
+   the time pushes that well above a ninth, and separating the showings in time
+   reduces the correlation between them without removing it, so even the
+   estimate is a floor rather than the rate. Report the observed unanimity rate
+   against it. A rate near the floor on the close pairs says the rater is not
+   separating them, which answers the question without a metric and means no
    metric can be validated on them either. A pair the rater flips on is a pair
    no metric can be scored against.
 3. **Select on one half, validate on the other.** Split the pairs into a

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -683,10 +683,13 @@ would settle it and costs one more render pass.
 | 0.05      | 0.00322 [0.00291, 0.00353]   | 43.20   | 0.00775 [0.00715, 0.00834]   | 42.14   |
 | 0.1       | 0.02032 [0.01871, 0.02191]   | 34.01   | 0.05406 [0.05050, 0.05780]   | 31.59   |
 
-These are lossless renders. The first attempt used the q95 JPEGs the render
-script writes by default and produced 0.00085 and 0.00038 at the 0.01 rung,
-seventeen and nineteen times the truth. Encoding the same checkpoint twice and
-comparing the copies puts the encoder's own error at 0.00795 LPIPS and 48.5 dB,
+These are lossless renders. The first attempt wrote JPEG at quality 95, which is
+what the throwaway render script used for this experiment did, and produced
+0.00085 and 0.00038 at the 0.01 rung, seventeen and nineteen times the truth.
+The repository's own orbit renderer defaults to JPEG at quality 100, so the
+figure below is an upper bound on what that one costs rather than a measurement
+of it. Encoding the same checkpoint twice at q95 and comparing the copies puts
+the encoder's error at 0.00795 LPIPS and 48.5 dB,
 which is nothing against a photograph, since renders sit around 22 dB from
 those, and overwhelming against another render at 61 to 68 dB. The artifacts
 mostly cancel between two nearly identical images and decorrelate as the images

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -438,7 +438,7 @@ Steps, with an interval excluding zero marked R:
 | gaudi step      | ΔFID                      | ΔKID x1000                | ΔCMMD                        |
 | --------------- | ------------------------- | ------------------------- | ---------------------------- |
 | 0 → 0.00392     | +0.000 [+0.000, +0.000]   | +0.000 [+0.000, +0.000]   | +0.0000 [+0.0000, +0.0000]   |
-| 0.00392 → 0.01  | -0.028 [-0.097, +0.027]   | -0.039 [-0.072, -0.006] R | +0.0009 [-0.0002, +0.0022]   |
+| 0.00392 → 0.01  | -0.028 [-0.097, +0.027]   | -0.039 [-0.072, -0.006]   | +0.0009 [-0.0002, +0.0022]   |
 | 0.01 → 0.02     | -0.024 [-0.169, +0.107]   | -0.059 [-0.203, +0.048]   | -0.0000 [-0.0024, +0.0022]   |
 | 0.02 → 0.05     | +0.702 [+0.221, +1.409]   | +0.041 [-0.318, +0.793]   | +0.0132 [+0.0099, +0.0179] R |
 | 0.05 → 0.1      | +4.772 [+3.964, +6.823] R | +1.634 [+0.634, +3.528]   | +0.0618 [+0.0465, +0.0883] R |
@@ -454,22 +454,26 @@ Steps, with an interval excluding zero marked R:
 The coarse end belongs to CMMD and FID. CMMD resolves all four coarse steps,
 FID three of them, and the two agree on direction throughout. KID resolves one,
 r2d2's 0.05 to 0.1. An interval carries the R only where the percentile and the
-basic construction agree, and the step FID loses that way is gaudi's 0.02 to
-0.05: the percentile interval is [+0.221, +1.409] on an estimate of +0.702, and
-reflecting it about the estimate gives [-0.006, +1.182]. It crosses zero by less
-than a hundredth of the step. At 400 replicates it did not cross at all; four
-thousand put the upper tail further out and the reflected lower end followed it
-down through zero, which is what happens to a verdict that was never far from
-the line.
+basic construction agree and the block-length sweep does not overturn them, the
+two conditions set out under "What the intervals assume" below. The step FID
+loses on the first of them is gaudi's 0.02 to 0.05: the percentile interval is
+[+0.221, +1.409] on an estimate of +0.702, and reflecting it about the estimate
+gives [-0.006, +1.182]. It crosses zero by less than a hundredth of the step.
+At 400 replicates it did not cross at all; four thousand put the upper tail
+further out and the reflected lower end followed it down through zero, which is
+what happens to a verdict that was never far from the line.
 
-Two fine steps resolve, on different scenes and pointing opposite ways. CMMD
-takes r2d2's 0.01 to 0.02 at +0.0071 with [+0.0045, +0.0095], the pruning
-scoring worse. KID takes gaudi's 0.00392 to 0.01 at -0.039 with
-[-0.072, -0.006], the pruning scoring better, and that is the weakest resolution
-in either table: the near end of the interval sits at a sixth of the estimate,
-and the block-length check below is unkind to it. CMMD puts that same step at
-+0.0009, the other way, and does not resolve it. On the remaining fine steps
-every metric spans zero.
+The fine end resolves once, for CMMD, on r2d2's 0.01 to 0.02 step at +0.0071
+with [+0.0045, +0.0095]. FID spans zero there, and on the other three fine steps
+every metric does.
+
+One fine step nearly joins it and is worth naming because it does not. KID puts
+gaudi's 0.00392 to 0.01 at -0.039 with [-0.072, -0.006], reading the pruning as
+an improvement where CMMD reads +0.0009 the other way, and that interval clears
+zero under both constructions at the block length these tables use. It does not
+clear at every block length the sweep below tries, and there is no selector
+behind the choice of 20 for a set-level statistic, so the exclusion is a
+property of the resampling scheme and carries no R.
 
 The disagreement on r2d2's 0.01 to 0.02 step used to be sharper. KID gives
 -0.061 there on the same images and the same frames, and under the standard
@@ -477,7 +481,7 @@ estimator its interval excluded zero under both constructions, so two estimators
 were resolving one step in opposite directions. That was never a fact about the
 images. It came from the paired cross terms below, and once those are removed
 the basic interval reads [-0.098, +0.003] and only CMMD is left saying anything.
-What survives, on both that step and gaudi's fine one, is a weaker statement
+What survives, on that step and on gaudi's fine one, is a weaker statement
 worth keeping: a polynomial-kernel distance on Inception features and an RBF
 distance on CLIP features can move in opposite directions on the same change
 without either being wrong, so at most one of them tracks any single notion of
@@ -487,11 +491,10 @@ An earlier version of this section had FID resolving gaudi's 0.00392 to 0.01
 step as an improvement, and I read that as the metric misbehaving. It was the
 JPEG encoder, and it vanished when the renders were written losslessly. Worth
 recording, because a resolved interval on an artifact is the exact failure this
-document is about, produced while writing it. KID now resolves that same step in
-that same direction on the lossless renders, which is not the same finding: the
-images it is separating differ by the pruning and by nothing else. Whether a
-distance of 0.039 in KID units is worth separating is the question no bound
-here settles.
+document is about, produced while writing it. KID puts that same step in that
+same direction on the lossless renders, which is not the same failure: the
+images it is separating differ by the pruning and by nothing else. It is also
+not a finding, for the reason above.
 
 #### A flaw in the standard KID protocol
 
@@ -532,13 +535,13 @@ goes from +0.499 to +0.448 and its 0.05 to 0.1 from +3.735 to +3.521. The
 correction to the levels also shrinks as the rungs coarsen instead of holding
 constant, which is the configuration dependence showing up directly.
 
-It swaps which fine step KID resolves. With the paired terms in, r2d2's 0.01 to
-0.02 excludes zero under both constructions and gaudi's 0.00392 to 0.01 does
-not; with them out it is the other way round. The r2d2 step is the one that used
-to disagree with CMMD, and the disagreement was an artifact of the estimator.
-The tables above are the paired-U column throughout, which leaves KID resolving
-two of the eight steps, r2d2's 0.05 to 0.1 and gaudi's 0.00392 to 0.01, the
-second of them barely.
+It swaps which fine step KID excludes zero on. With the paired terms in, r2d2's
+0.01 to 0.02 excludes it under both constructions and gaudi's 0.00392 to 0.01
+does not; with them out it is the other way round. The r2d2 step is the one that
+used to disagree with CMMD, and the disagreement was an artifact of the
+estimator. Neither survives the block-length check, so the tables, which are the
+paired-U column throughout, leave KID resolving one of the eight steps, r2d2's
+0.05 to 0.1.
 
 FID is untouched. It uses each set's own mean and covariance and never forms a
 cross-set kernel, so there is no paired term in it to remove.
@@ -562,15 +565,23 @@ estimating the resampling expectation rather than the difference that was
 measured, and it would make the point estimate depend on the replicate count and
 the seed. The interval is the 2.5th and 97.5th percentile of the replicate
 differences. R marks a step that excludes zero under both interval
-constructions. The set-level tables use 4000 replicates, the per-frame LPIPS
-ones 2000, and the walkthrough comparison quoted earlier 20000. The set-level
-run seeds one generator per step rather than one per run, so the Inception pass
-and the CLIP pass, which need different environments and cannot share a process,
-still resample the same frames in the same order and the three columns of a row
-are one resample rather than three. FID uses the low-rank Frechet identity
-described below, KID the unbiased estimator on the full set with no subset
-averaging and with the paired cross terms dropped, and CMMD the V-statistic
-accumulated in float64.
+constructions at the block length reported and at every block length in the
+sweep below, which is the stricter rule the sweep forced: a verdict that appears
+only inside a band of block lengths is a property of the resampling scheme,
+since nothing here selects a block length for a set-level statistic the way
+Politis and White select one for a mean.
+
+The set-level tables use 4000 replicates, the per-frame LPIPS ones 2000, and the
+walkthrough comparison quoted earlier 20000. The set-level run seeds one
+generator per step rather than one per run, at 7000 plus the index of the step
+in ladder order counting from zero, so the Inception pass and the CLIP pass,
+which need different environments and cannot share a process, still resample the
+same frames in the same order and the three columns of a row are one resample
+rather than three. The block sweep seeds at 70000 plus 100 times the step index
+plus the block length, and the frame-count draws at 1100 plus the frame count.
+FID uses the low-rank Frechet identity described below, KID the unbiased
+estimator on the full set with no subset averaging and with the paired cross
+terms dropped, and CMMD the V-statistic accumulated in float64.
 
 Which point estimate gets reported is not a formality here. The replicates of a
 nonlinear statistic do not centre on the observed value, and the percentile
@@ -628,12 +639,13 @@ Two cases sit on the line rather than move around. r2d2's 0.01 to 0.02 KID step
 clears zero under the basic interval by 0.00014 at 2000 replicates and misses it
 by 0.0026 at 4000, same data and same block length, so the tables' unresolved
 verdict is the better tail estimate rather than a different finding. Gaudi's
-0.00392 to 0.01 KID step, the one the tables do mark, resolves under both
-constructions at every block length from 10 up and at none below: the i.i.d.
-bootstrap puts its upper end within 0.00001 of zero. Its interval also narrows
-monotonically as the blocks lengthen, from 0.081 at length 1 to 0.029 at 100, so
-that resolution is one the resampling scheme grants rather than one it survives.
-It is the weakest R in the document and nothing rests on it.
+0.00392 to 0.01 KID step excludes zero under both constructions at every block
+length from 10 up and at none below: the i.i.d. bootstrap puts its upper end
+within 0.00001 of zero. Its interval also narrows monotonically as the blocks
+lengthen, from 0.081 at length 1 to 0.029 at 100, so the exclusion is granted by
+the resampling scheme rather than survived. This is the case that set the rule
+above. It carries no R, and every step that does carries it at every block
+length tried.
 
 Past 40 the collapse manufactures resolutions outright: r2d2's 0.01 to 0.02
 turns resolved for FID at 60, gaudi's 0.00392 to 0.01 for CMMD at 80 and for FID
@@ -785,9 +797,9 @@ sensitivity looks like. Calling it an error would need an equivalence bound
 declared in advance and an interval that fits inside it, which is the same thing
 this document demands before anyone calls PSNR blind. No such bound exists here.
 
-So the fine end ranks nobody. FID resolves nothing there, CMMD resolves one
-step and KID another, in opposite directions on different scenes, and which of
-those is the right behaviour depends on a threshold nobody has set.
+So the fine end ranks nobody. FID and KID resolve nothing there, CMMD resolves
+one step, and which of those is the right behaviour depends on a threshold
+nobody has set.
 
 What does separate them needs no labels, because it is about the estimators
 rather than the images. Two things, and the first version of one of them was

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -428,18 +428,18 @@ Steps, with an interval excluding zero marked R:
 | gaudi step      | ΔFID                      | ΔKID x1000                | ΔCMMD                        |
 | --------------- | ------------------------- | ------------------------- | ---------------------------- |
 | 0 → 0.00392     | +0.000 [+0.000, +0.000]   | +0.000 [+0.000, +0.000]   | +0.0000 [+0.0000, +0.0000]   |
-| 0.00392 → 0.01  | -0.031 [-0.088, +0.030]   | -0.036 [-0.065, +0.010]   | +0.0010 [-0.0002, +0.0023]   |
-| 0.01 → 0.02     | -0.029 [-0.172, +0.100]   | -0.062 [-0.198, +0.035]   | +0.0000 [-0.0023, +0.0023]   |
-| 0.02 → 0.05     | +0.733 [+0.253, +1.339] R | +0.135 [-0.316, +0.762]   | +0.0136 [+0.0099, +0.0184] R |
-| 0.05 → 0.1      | +5.340 [+4.105, +6.951] R | +2.075 [+0.929, +3.961] R | +0.0637 [+0.0470, +0.0862] R |
+| 0.00392 → 0.01  | -0.028 [-0.088, +0.030]   | -0.038 [-0.065, +0.010]   | +0.0009 [-0.0002, +0.0023]   |
+| 0.01 → 0.02     | -0.024 [-0.172, +0.100]   | -0.055 [-0.198, +0.035]   | -0.0000 [-0.0023, +0.0023]   |
+| 0.02 → 0.05     | +0.702 [+0.253, +1.339] R | +0.047 [-0.316, +0.762]   | +0.0132 [+0.0099, +0.0184] R |
+| 0.05 → 0.1      | +4.772 [+4.105, +6.951] R | +1.694 [+0.929, +3.961] R | +0.0618 [+0.0470, +0.0862] R |
 
 | r2d2 step       | ΔFID                         | ΔKID x1000                | ΔCMMD                        |
 | --------------- | ---------------------------- | ------------------------- | ---------------------------- |
 | 0 → 0.00392     | +0.000 [+0.000, +0.000]      | +0.000 [+0.000, +0.000]   | +0.0000 [+0.0000, +0.0000]   |
-| 0.00392 → 0.01  | +0.001 [-0.013, +0.012]      | -0.004 [-0.017, +0.008]   | +0.0006 [-0.0007, +0.0018]   |
-| 0.01 → 0.02     | -0.051 [-0.116, +0.009]      | -0.067 [-0.118, -0.024] R | +0.0072 [+0.0048, +0.0096] R |
-| 0.02 → 0.05     | +1.626 [+1.054, +2.246] R    | +0.561 [+0.135, +1.081] R | +0.0752 [+0.0624, +0.0876] R |
-| 0.05 → 0.1      | +12.001 [+9.925, +14.690] R  | +4.400 [+2.937, +6.391] R | +0.2511 [+0.2039, +0.2937] R |
+| 0.00392 → 0.01  | -0.001 [-0.013, +0.012]      | -0.005 [-0.017, +0.008]   | +0.0006 [-0.0007, +0.0018]   |
+| 0.01 → 0.02     | -0.049 [-0.116, +0.009]      | -0.059 [-0.118, -0.024] R | +0.0071 [+0.0048, +0.0096] R |
+| 0.02 → 0.05     | +1.511 [+1.054, +2.246] R    | +0.499 [+0.135, +1.081] R | +0.0746 [+0.0624, +0.0876] R |
+| 0.05 → 0.1      | +10.577 [+9.925, +14.690] R  | +3.735 [+2.937, +6.391] R | +0.2442 [+0.2039, +0.2937] R |
 
 The coarse end is close to unanimous. Every metric resolves 0.05 to 0.1 in both
 scenes, and 0.02 to 0.05 goes the same way everywhere except KID on gaudi. The
@@ -447,8 +447,8 @@ weakest of the resolved cases is FID on gaudi's 0.02 to 0.05 step, where the
 interval's near end still sits a third of the way to the estimate.
 
 The fine end resolves once, and the one time it does the metrics disagree about
-which way. On r2d2's 0.01 to 0.02 step KID reports -0.067 with an interval of
-[-0.118, -0.024] while CMMD reports +0.0072 with [+0.0048, +0.0096]: same
+which way. On r2d2's 0.01 to 0.02 step KID reports -0.059 with an interval of
+[-0.118, -0.024] while CMMD reports +0.0071 with [+0.0048, +0.0096]: same
 images, same frames, both excluding zero, opposite signs. FID spans zero there,
 and on the other three fine steps all three metrics do. That is less damning
 than it first looks. KID measures a polynomial-kernel distance between Inception
@@ -492,16 +492,27 @@ starts uniformly from 0 to n-1, takes L consecutive indices from each with
 wraparound past the end of the sequence, concatenates them and truncates back
 to n. One index set per replicate indexes the configuration under test, the one
 it is compared against, and the reference set alike, so the pairing survives the
-resample. The reported difference is the mean over replicates, the interval is
-their 2.5th and 97.5th percentiles, and R marks an interval that does not
-contain zero. The set-level tables use 400 replicates, the per-frame LPIPS ones
-2000, and the walkthrough comparison quoted earlier 20000. Each run seeds one
-generator at 0 and draws every step of the ladder from it in sequence, so
-rerunning a single step alone reproduces its estimate but not its exact
-interval, and the endpoints move in their last quoted digit between generators
-anyway. FID uses the low-rank Frechet identity described below, KID the
-unbiased estimator on the full set with no subset averaging, and CMMD the
-V-statistic accumulated in float64.
+resample. The reported difference is the statistic on the observed sample. The
+mean over the replicates is a different quantity for a nonlinear statistic,
+estimating the resampling expectation rather than the difference that was
+measured, and it would make the point estimate depend on the replicate count and
+the seed. The interval is the 2.5th and 97.5th percentile of the replicate
+differences, and R marks an interval that does not contain zero. The set-level
+tables use 400 replicates, the per-frame LPIPS ones 2000, and the walkthrough
+comparison quoted earlier 20000. Every generator is seeded at 0, and the
+set-level runs draw the whole ladder from one of them in sequence, so those
+intervals are reproducible as a set rather than one step at a time. Their
+endpoints move in the last quoted digit between generators in any case. FID uses
+the low-rank Frechet identity described below, KID the unbiased estimator on the
+full set with no subset averaging, and CMMD the V-statistic accumulated in
+float64.
+
+Which point estimate gets reported is not a formality here. On r2d2's 0.05 to
+0.1 step the replicate mean sits at 12.00 FID against 10.58 observed and at 4.40
+KID against 3.74, so the percentile interval is dragged along with it and the
+observed value lands near its lower end rather than in the middle. CMMD moves by
+under three percent on the same step. Read the coarse FID and KID intervals as
+offset from their estimates rather than centred on them.
 
 How much it costs splits the metrics in two, and the split is the useful part of
 the check. Interval width at block length 20 over width at block length 1:
@@ -534,12 +545,13 @@ million, with the residual a constant offset that cancels in a difference, and
 400 replicates now cost less than 25 did.
 
 Two classifications moved between them, both from resolved to unresolved. KID
-resolved gaudi's 0.00392 to 0.01 step under the i.i.d. bootstrap, at -0.037 with
-[-0.072, -0.001], and does not under blocks, at -0.036 with [-0.065, +0.010].
-FID resolved r2d2's 0.01 to 0.02 step on 25 replicates, at -0.052 with
-[-0.098, -0.001], and does not on 400, at -0.051 with [-0.116, +0.009]. Neither
-estimate shifted; both intervals grew past zero, which is what the fine end
-looks like once the interval stops being optimistic.
+resolved gaudi's 0.00392 to 0.01 step under the i.i.d. bootstrap, where -0.038
+carried [-0.072, -0.001], and does not under blocks, where the same -0.038
+carries [-0.065, +0.010]. FID resolved r2d2's 0.01 to 0.02 step on 25
+replicates, where -0.049 carried [-0.098, -0.001], and does not on 400, where it
+carries [-0.116, +0.009]. The estimate cannot move, since it is the difference
+on the observed sample either way; both intervals grew past zero, which is what
+the fine end looks like once the interval stops being optimistic.
 
 CMMD needed a third. The implementation here is Google's, which uses the biased
 V-statistic rather than the unbiased U-statistic, and its bias is not a constant
@@ -549,8 +561,8 @@ and that quantity depends on the configuration being scored. On this ladder it
 does not move. The excess is 0.0160 on gaudi and 0.0156 on r2d2, the same to
 four decimals across all six rungs, and the configuration-dependent factor
 varies only in the fifth decimal. Recomputing every step with the unbiased
-estimator shifts none of them by more than 0.0007 and leaves every
-classification standing: r2d2's 0.01 to 0.02 step reads +0.0072 with
+estimator shifts none of them by more than 0.00015 and leaves every
+classification standing: r2d2's 0.01 to 0.02 step reads +0.0071 with
 [+0.0048, +0.0096] biased and +0.0071 with [+0.0047, +0.0095] unbiased.
 
 Checking that turned up a fourth thing, which has nothing to do with either
@@ -636,10 +648,10 @@ differ:
 
 | step             | FID  | KID  | CMMD  |
 | ---------------- | ---- | ---- | ----- |
-| gaudi 0.02→0.05  | 2.65 | 0.49 | 6.27  |
-| gaudi 0.05→0.1   | 7.35 | 2.68 | 6.38  |
-| r2d2 0.02→0.05   | 5.35 | 2.33 | 11.69 |
-| r2d2 0.05→0.1    | 9.87 | 4.99 | 10.96 |
+| gaudi 0.02→0.05  | 2.53 | 0.17 | 6.10  |
+| gaudi 0.05→0.1   | 6.57 | 2.19 | 6.18  |
+| r2d2 0.02→0.05   | 4.97 | 2.07 | 11.59 |
+| r2d2 0.05→0.1    | 8.70 | 4.24 | 10.66 |
 
 CMMD leads in three of the four and KID trails in all four, while FID takes the
 largest step on gaudi's coarsest. That is the comparison this conclusion

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -260,9 +260,11 @@ estimator Google published, which `clip-mmd` vendors verbatim, is the
 minimum-variance form of Gretton et al.'s Eq. (5). It averages the kernel matrix
 including its diagonal, so it is the biased V-statistic, not the unbiased one
 that makes KID safe at small n. The docstring argues the two are almost
-identical, citing the proof of Lemma 6 in the same paper, and for ranking
-configurations at a fixed sample size the difference does not bite. KID is still
-the one with the cleaner claim.
+identical, citing the proof of Lemma 6 in the same paper. That argument does not
+carry on its own, because the diagonal term each configuration contributes
+depends on its own within-set similarities and so need not cancel between two of
+them. Measured, it does cancel here; the numbers are under "What the intervals
+assume". KID is still the one with the cleaner claim.
 
 Three cautions before treating any of them as an answer.
 
@@ -594,12 +596,12 @@ everything as a constant floor: seventeen times at 0.01, six at 0.02, and still
 Every problem the distribution metrics had disappears. The ladder is monotone in
 both scenes. No neighbouring pair of intervals overlaps. The identity rung
 returns exactly zero with infinite PSNR, which is a fact rather than a
-calibration hope. Where FID and KID both invert on both scenes and all three
-leave the fine rungs unresolved, this separates all five rungs in both scenes,
-and the intervals are narrow enough that the separation is not close. CMMD
-orders the ladder correctly, which is the one thing at the fine end it does that
-the other two do not, though every fine step of that ordering sits inside an
-interval spanning zero.
+calibration hope. Where FID and KID both invert on both scenes and the three of
+them together resolve one fine step out of eight, this separates all five rungs
+in both scenes, and the intervals are narrow enough that the separation is not
+close. CMMD does better than the other two at the fine end: it orders both
+ladders correctly, and it resolves r2d2's 0.01 to 0.02 step, which KID also
+resolves in the opposite direction.
 
 The reason is not that LPIPS is a better metric than CMMD. It is that the
 comparison is paired at the level of individual frames against an exact

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -1021,12 +1021,21 @@ The proposed experiment, in order:
    rater who splits the three responses evenly and answers each showing
    independently of the last, and no one does the first. Estimate it from the
    rater's own marginal frequencies instead, as the chance that three
-   independent draws from those frequencies agree, which is p_left cubed plus
-   p_right cubed plus p_none cubed. A rater who answers "no difference" most of
-   the time pushes that well above a ninth, and separating the showings in time
-   reduces the correlation between them without removing it, so even the
-   estimate is a floor rather than the rate. Report the observed unanimity rate
-   against it. A rate near the floor on the close pairs says the rater is not
+   independent draws from those frequencies agree, which is p_A cubed plus p_B
+   cubed plus p_none cubed. Those marginals are over the configuration the
+   answer named, not over the side it was on, for the same reason the answers
+   themselves are recorded that way: sides are redrawn at every showing, so a
+   rater who always clicks left has p_left of 1 and a side-based floor of 1,
+   while the labels their clicks actually produce are an even split between the
+   two configurations and unanimous a quarter of the time. A quarter is the
+   floor that rater's data supports, and it is what "a fixed-side habit looks
+   like guessing" means once it is a number. A rater who answers "no
+   difference" most of the time pushes the floor well above a ninth in the
+   other direction, and separating the showings in time reduces the correlation
+   between them without removing it, so even the estimate is a floor rather
+   than the rate. Report the observed unanimity rate against it, and report the
+   side marginals too: they diagnose the habit that the configuration marginals
+   absorb. A rate near the floor on the close pairs says the rater is not
    separating them, which answers the question without a metric and means no
    metric can be validated on them either. A pair the rater flips on is a pair
    no metric can be scored against.

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -94,39 +94,158 @@ to 232.9 MB over the same range, so the decision has a real cost on one side and
 an unverified benefit on the other.
 
 **The cleanup threshold.** Filtering at opacity 0.05 removes between 4.9% and
-62% of the Gaussians depending on the scene. 3DGS-QA measured perceptual cost
-for content-blind random pruning at 25/50/75% and found it degrades MOS
-smoothly. Our filter is attribute-based, not random: it targets Gaussians the
-model itself marked as nearly transparent. Pruning what the model
-already considers invisible should cost less than pruning at random, but no
-study has measured it. The 62% cases
-are the ones to worry about, and we have no evidence either way.
+62% of the Gaussians depending on the scene, and it is not free. Paired testing
+puts the cost at 0.0007 LPIPS on `gaudi_fountain` and 0.0059 on `r2d2_new`, the
+same sign on every frame of both, with PSNR and SSIM agreeing. It was called
+free because the marginal spread is 0.05 and 0.035, which buried it. The cost is
+small enough that a median 28% size saving is still worth paying, but "free" was
+the wrong word and it was reached the wrong way.
+
+3DGS-QA measured content-blind random pruning at 25/50/75% and found it degrades
+MOS smoothly. Our filter is attribute-based, targeting Gaussians the model
+itself marked nearly transparent, which should cost less than random pruning at
+the same rate. Nobody has measured that, and the 62% scenes remain the ones to
+worry about.
 
 **The container choice.** SPZ against SOG is a quantisation decision applied to
 a fixed set of Gaussians. GS-QA evaluates SOG, but as a reconstruction *method*
 with spherical harmonics removed during training, not as a container applied
 afterwards. Nothing published covers our version of the question.
 
-**The frame-count experiment.** Ran at 106 and 212 training views against a
-pinned 11-frame held-out set: PSNR 20.05 against 20.10, SSIM 0.519 against
-0.532, LPIPS 0.3645 against 0.3677. Both configurations were scored on the same
-11 frames, which means the comparison is paired and the per-image standard
-deviation is the wrong yardstick for it.
+**The frame-count experiment.** Invalid, and not for a subtle reason. The design
+held a fixed set of 11 source frames out of every configuration so the two runs
+would be scored on the same ground truth. It did not survive contact with
+`ceil`. The split fraction has to be `(N-E)/N` exactly; the script validated
+that at full precision and then passed a six-decimal rounding to training, and
+`0.905983 * 117` is `106.00001`, so `ceil` returned 107 instead of 106. Both
+configurations held out 10 frames instead of 11, at different positions, and the
+two runs share exactly one ground-truth image out of ten. The reported tie
+compared different pictures.
 
-That deviation, 0.063 to 0.070 on LPIPS, is dominated by how hard each frame is,
-and frame difficulty is shared between the two runs. It cancels in the
-per-frame differences. A change of 0.003 that pointed the same way on all 11
-frames would be a real effect hiding inside a spread twenty times its size,
-and comparing the gap to the marginal spread cannot tell that apart from noise.
-`ns-eval` reports only aggregates, so the per-frame values needed to settle it
-were never written down.
+The fix is to stop deriving the split from a float. Name the files so
+`eval_mode=filename` selects them, which cannot drift. Retraining is cheap
+because the SfM output already exists.
 
-This is not a frame-count problem. Every "inside the spread, therefore no
-difference" verdict in this project was reached the same way, including the ones
-for opacity pruning, `rasterize_mode` and appearance embeddings. Pairing raises
-sensitivity, so the direction of the error is one-sided: effects called noise
-may be real, while effects already called real stay real. Re-running eval with
-per-frame output is cheap and comes before trusting any of those nulls.
+## What pairing changed
+
+Matched runs are scored on the same eval frames, so the comparison is paired and
+the per-frame difference is the quantity with a meaningful spread. `ns-eval`
+reports only the mean and the marginal standard deviation, which is dominated by
+how hard each frame is, and that difficulty is shared between the runs and
+cancels in the differences. Re-running eval with per-frame output and testing
+the differences directly changes several verdicts.
+
+LPIPS, mean paired difference with a 95% interval, and how often the difference
+kept its sign across frames:
+
+| Comparison | n | Mean diff | 95% CI | Paired SD | Marginal SD | Same sign |
+|---|---|---|---|---|---|---|
+| seed off to on | 5 | -0.0810 | [-0.155, -0.007] | 0.060 | 0.070 | 5/5 |
+| cap 100k to 250k | 5 | -0.0803 | [-0.097, -0.064] | 0.013 | 0.064 | 5/5 |
+| cap 250k to 500k | 5 | -0.0505 | [-0.064, -0.037] | 0.011 | 0.050 | 5/5 |
+| classic to antialiased | 5 | +0.0016 | [-0.004, +0.007] | 0.005 | 0.064 | 3/5 |
+| prune 0.05, gaudi | 5 | +0.0007 | [+0.0004, +0.0010] | 0.0002 | 0.050 | 5/5 |
+| prune 0.1, gaudi | 5 | +0.0042 | [+0.003, +0.005] | 0.0009 | 0.050 | 5/5 |
+| prune 0.05, r2d2 | 7 | +0.0059 | [+0.004, +0.008] | 0.002 | 0.035 | 7/7 |
+| prune 0.1, r2d2 | 7 | +0.0373 | [+0.029, +0.046] | 0.010 | 0.038 | 7/7 |
+
+Three things fall out.
+
+**Opacity pruning is not free.** At 0.05 it costs 0.0007 LPIPS on gaudi and
+0.0059 on r2d2, and the sign holds on every frame of both scenes, with PSNR and
+SSIM agreeing. The marginal spread is 70 times the gaudi effect, which is why it
+read as noise. The trade is still worth taking for a median 28% size cut. The
+verdict of "free" was not.
+
+**PSNR and SSIM really are blind to the Gaussian budget.** This one survives
+pairing and gets stronger for it. Across both cap steps the PSNR interval
+contains zero and the sign splits 3/5, while LPIPS separates every step cleanly.
+Pairing removed the excuse that the effect was hiding in the noise: it is not
+there.
+
+**Effects come in two kinds, and the marginal spread cannot tell them apart.**
+Seeding moves LPIPS by 0.081 with a paired SD of 0.060, almost as large as the
+marginal spread, so it helps some frames far more than others. Pruning at 0.05
+moves it by 0.0007 with a paired SD of 0.0002, a consistent tax on every frame.
+Judged against the marginal spread the first looks significant and the second
+looks absent, when what actually separates them is homogeneity, not size.
+
+One near miss is worth recording. Pairing the antialiased run against the
+obvious partner made `rasterize_mode` look like a 0.083 LPIPS regression, which
+would have overturned a correct result. The run predates the seed point cloud
+landing in that scene directory, so the number was the seeding effect wearing a
+different label. Timestamps caught it. Against its actual control the difference
+is 0.0016 with the sign splitting 3/5, and `rasterize_mode` stays free.
+
+## Would FID or KID do better?
+
+Worth separating the premise first: LPIPS is not one of the metrics that works.
+It scored 0.41, 0.34 and 0.51 in the three studies, at or below PSNR every time.
+What worked was DISTS at 0.73 and the no-reference video models above 0.93. The
+dividing line is not deep features against hand-built ones, since LPIPS and
+DISTS are both deep-feature metrics separated by 0.4 in correlation.
+
+FID and KID are a different kind of thing again. Both compare *distributions* of
+features between two sets of images rather than scoring one image against
+another, which gives them one property nothing else here has: they need no
+correspondence between the sets. An A/B of two orbits has no per-frame ground
+truth, since a novel camera path has no photograph, and that is exactly why
+DISTS and CW-SSIM cannot be used on it. A set-level metric can compare the orbit
+renders against the original capture frames without any pose in common, which
+matches the delivery question directly. Does this exported asset still look like
+photographs of this scene?
+
+The one measurement available is MUGSQA's, which reports FID at 0.52 Spearman on
+its main set and 0.77 on its additional set, second best of everything it tried
+there. The gap between the two is informative. The main set spans 55 different
+objects; the additional set fixes 3 objects and varies the reconstruction method.
+A distribution metric compares content and quality at once, so when content
+varies it measures mostly content. Fixed content with varying settings is our
+case and is the regime where it did well.
+
+Sample size is the obstacle. FID fits a Gaussian to each set and estimates a
+2048-dimensional covariance, which on 11 eval frames has rank at most 10 and is
+meaningless. The bias is well documented, and the part that matters is that it
+depends on the model being scored, so evaluating two configurations at the same
+small n does not cancel it. Chong and Forsyth propose extrapolating to infinite
+samples to get around this; common practice is tens of thousands of images.
+
+KID is the answer to that. It replaces the Fréchet distance with a
+polynomial-kernel MMD that has an unbiased estimator and assumes nothing about
+the distribution, which is what makes it usable at small n. Variance still falls
+with sample size, but the bias does not depend on it, so a comparison at fixed
+small n means something. Between the two, KID is the one to reach for here.
+
+CMMD is the stronger version of the same idea. Jayasumana et al. argue FID fails
+on three counts at once, with Inception features too narrow for varied content,
+a normality assumption that does not hold, and poor sample complexity, and show
+it contradicting human raters and reordering itself as sample size changes.
+Their replacement keeps the MMD but swaps in CLIP embeddings and a Gaussian RBF
+kernel. Unbiased, distribution-free, sample efficient, and available as
+`clip-mmd`. If the goal is a feature-based distributional metric, this is the
+current best version of it.
+
+Three cautions before treating any of them as an answer.
+
+They give one number per set, so they cannot be paired the way everything in the
+table above was. Uncertainty has to come from bootstrapping over frames, and the
+paired comparison that made the pruning effect visible has no analogue.
+
+They are insensitive to exactly the errors a reconstruction makes. A render that
+is plausible but geometrically wrong scores well, because the feature
+distribution does not encode where anything is. This is a known failure in
+view-synthesis evaluation, where distribution metrics improve while frame to
+frame consistency gets worse.
+
+The natural reference set is our own capture frames, which contain the tourists.
+A model that correctly drops a transient gets penalised for not matching, the
+same bias already documented for the held-out frames.
+
+The honest recommendation is to test KID or CMMD as a companion, not a
+replacement, and to put it through the same ladder as everything else. Render a
+few hundred orbit frames per configuration, which costs nothing, use the capture
+frames as the reference set, and require it to order a degradation ladder
+correctly before asking it anything harder.
 
 ## What to measure instead
 
@@ -238,3 +357,14 @@ rather than settled until step 1 above runs on our own data.
 - GS-QA: [arXiv:2502.13196](https://arxiv.org/abs/2502.13196)
 - GGSC compression benchmark: [arXiv:2407.14197](https://arxiv.org/abs/2407.14197),
   code at [Qi-Yangsjtu/GGSC](https://github.com/Qi-Yangsjtu/GGSC)
+
+Distribution metrics:
+
+- KID: [arXiv:1801.01401](https://arxiv.org/abs/1801.01401), Bińkowski et al.,
+  the unbiased MMD estimator FID lacks
+- FID sample-size bias: [arXiv:1911.07023](https://arxiv.org/abs/1911.07023),
+  Chong and Forsyth
+- CMMD: [arXiv:2401.09603](https://arxiv.org/abs/2401.09603), Jayasumana et al.,
+  CLIP features plus MMD, packaged as `clip-mmd`
+- ImageNet class dependence of FID:
+  [arXiv:2203.06026](https://arxiv.org/abs/2203.06026), Kynkäänniemi et al.

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -1,0 +1,162 @@
+# Evaluating splat quality
+
+`ns-eval` reports PSNR, SSIM and LPIPS on held-out views. Every tuning decision
+this pipeline makes has been justified with those three numbers. Four subjective
+studies published between 2024 and 2025 measured how well those numbers track
+what people see in a Gaussian splat, and the answer is: not well enough
+to settle a close call.
+
+This document collects the evidence, says which of our decisions it invalidates,
+and proposes what to measure instead.
+
+## What the studies found
+
+Each study collected Mean Opinion Scores from human viewers on a set of
+deliberately degraded splats, then asked how well each objective metric
+reproduced the human ranking. Numbers below are Spearman rank correlation with
+MOS. Higher is better; 1.0 would mean the metric orders stimuli exactly as
+people do.
+
+| Metric | 3DGS-VBench | MUGSQA (main) | 3DGS-QA |
+|---|---|---|---|
+| PSNR | 0.50 | 0.52 | not reported |
+| SSIM | 0.51 | 0.37 | 0.31 |
+| MS-SSIM | 0.50 | 0.64 | not reported |
+| LPIPS | 0.51 | 0.41 (VGG) / 0.44 (Alex) | 0.34 |
+| FSIM | 0.59 | 0.68 | not reported |
+| IW-SSIM | 0.63 | not reported | not reported |
+| CW-SSIM | not reported | 0.74 | not reported |
+| DISTS | 0.73 | not reported | not reported |
+| BRISQUE | 0.24 | not reported | 0.33 |
+| DOVER | **0.94** | not reported | not reported |
+| VSFA | **0.94** | not reported | not reported |
+| FAST-VQA | **0.93** | not reported | 0.29 |
+| DBCNN (fine-tuned) | not reported | **0.88** | not reported |
+| GSOQA (fine-tuned) | not reported | not reported | **0.77** |
+
+The three studies disagree on plenty, and they degrade splats in different ways.
+They agree on the part that matters here: PSNR, SSIM and LPIPS all land near 0.5
+or below, and none of the three separates itself from the other two.
+
+The papers also report Kendall correlation, which converts to something more
+concrete. Ignoring ties, a metric with Kendall tau of t orders a random pair of
+stimuli the way a human would about (1+t)/2 of the time. On 3DGS-VBench that
+puts PSNR at 68%, LPIPS at 68% and DISTS at 76%. On 3DGS-QA, LPIPS drops to 64%.
+A coin flip is 50%. When we compare two configurations and one wins on LPIPS,
+the odds that a viewer agrees are closer to two in three than to a settled
+result.
+
+### What each study degraded
+
+The studies are not interchangeable, and the differences decide which of our
+questions they can answer.
+
+**3DGS-VBench** ([2508.07038](https://arxiv.org/abs/2508.07038)) is the one aimed
+at delivery. 660 compressed models, 11 scenes, six compression methods at
+several parameter levels each, 50 participants scoring rendered videos. This is
+the closest published analogue to our own container and pruning decisions.
+
+**MUGSQA** ([2511.06830](https://arxiv.org/abs/2511.06830)) varies the input
+instead: view count (72/36/9), resolution (1080/720/480 square), camera distance
+(5 m/2 m/1 m) and point cloud initialisation quality. 1,970 samples from 55
+Sketchfab meshes rendered in Blender with exact poses in NeRF-synthetic format.
+This is the synthetic ground-truth benchmark we sketched out for ourselves. It
+exists, and the code and data are released.
+
+**3DGS-QA** ([2511.08032](https://arxiv.org/abs/2511.08032)) degrades the
+exported asset directly: primitive count reduced to 75/50/25%, positional noise,
+spherical harmonic perturbation, plus reduced views and truncated training.
+225 models across 15 object types. Its downsampling axis is the nearest thing
+in the literature to our cleanup script, with one difference that matters (see
+below).
+
+**GS-QA** ([2502.13196](https://arxiv.org/abs/2502.13196)) is the dissenting
+result: correlations above 0.8 for 360-degree scenes, with FSIM and MS-SSIM on
+top and ST-LPIPS best on forward-facing scenes. The dissent is explainable. Its
+64 stimuli come from eight scenes crossed with seven GS methods plus
+Mip-NeRF 360, so the quality range is wide and the comparisons are coarse.
+Ranking Scaffold-GS against LightGaussian is not the same problem as ranking two
+parameter settings of one method, and the coarse comparison is the one the
+metrics handle.
+
+## What this invalidates
+
+**The cap_max sweep.** We measured 100k/250k/500k/1M Gaussians on
+`gaudi_fountain` and found PSNR and SSIM blind to the whole range while LPIPS
+moved from 0.451 to 0.282. We read that as LPIPS being the sensitive metric.
+The correlation numbers say something weaker: LPIPS moved, and we do not know
+how much of that motion a viewer would notice. The file size went from 23.8 MB
+to 232.9 MB over the same range, so the decision has a real cost on one side and
+an unverified benefit on the other.
+
+**The cleanup threshold.** Filtering at opacity 0.05 removes between 4.9% and
+62% of the Gaussians depending on the scene. 3DGS-QA measured perceptual cost
+for content-blind random pruning at 25/50/75% and found it degrades MOS
+smoothly. Our filter is attribute-based, not random: it targets Gaussians the
+model itself marked as nearly transparent. Pruning what the model
+already considers invisible should cost less than pruning at random, but no
+study has measured it. The 62% cases
+are the ones to worry about, and we have no evidence either way.
+
+**The container choice.** SPZ against SOG is a quantisation decision applied to
+a fixed set of Gaussians. GS-QA evaluates SOG, but as a reconstruction *method*
+with spherical harmonics removed during training, not as a container applied
+afterwards. Nothing published covers our version of the question.
+
+**The frame-count experiment.** Currently running at 106/212/424 training views
+with a pinned held-out set. MUGSQA's view-quantity axis is the closest prior
+work, and it also scores with 2D metrics, so it inherits the same ceiling. The
+experiment is still worth reading, but a small LPIPS delta between 212 and 424
+should not decide anything.
+
+## What to measure instead
+
+3DGS-VBench benchmarked five no-reference video quality models on compressed
+splats and found DOVER, VSFA and FAST-VQA all above 0.93 Spearman, against 0.51
+for the best of PSNR/SSIM/LPIPS. The paper describes no fine-tuning step for
+these models, so the numbers appear to be off-the-shelf pretrained weights
+applied to rendered videos. That is worth confirming against their code before
+leaning on it.
+
+If it holds, the recommendation is cheap to adopt. These models take a video,
+need no reference, and we already render orbit videos with `ns-render`. The
+change is one more step after export, not a new benchmark.
+
+The proposed experiment, in order:
+
+1. Run DOVER on the orbit renders from the cap_max sweep already on disk. Four
+   configurations, one scene, no new training. If DOVER separates them where
+   PSNR and SSIM did not, the metric earns its place.
+2. Extend to the cleanup threshold sweep, which is the decision with the widest
+   per-scene spread and the least published coverage.
+3. Only then consider generating our own stimuli. MUGSQA covers the input axes
+   and released its data, so the gap worth filling is attribute-based pruning
+   and container quantisation at fixed training, which is a much smaller build
+   than a full synthetic benchmark.
+
+## Caveats
+
+The correlations above are pooled across content. Predicting an absolute opinion
+score across 15 object types is harder than ranking two settings within one
+scene, so 0.5 is a lower bound on how much of our problem the metrics miss, not
+a direct estimate of how often our A/B comparisons are wrong.
+
+DBCNN at 0.88 and GSOQA at 0.77 are trained or cross-validated on the same
+dataset they score. They are not drop-in metrics.
+
+3DGS-QA reports FAST-VQA at 0.29 while 3DGS-VBench reports 0.93. The two
+datasets contain different distortions and different content, and neither paper
+explains the other's result. Treat the video-metric recommendation as promising
+rather than settled until step 1 above runs on our own data.
+
+## References
+
+- 3DGS-VBench: [arXiv:2508.07038](https://arxiv.org/abs/2508.07038), data at
+  [YukeXing/3DGS-VBench](https://github.com/YukeXing/3DGS-VBench)
+- MUGSQA: [arXiv:2511.06830](https://arxiv.org/abs/2511.06830), data at
+  [Solivition/MUGSQA](https://github.com/Solivition/MUGSQA)
+- 3DGS-QA: [arXiv:2511.08032](https://arxiv.org/abs/2511.08032), data at
+  [diaoyn/3DGSQA](https://github.com/diaoyn/3DGSQA)
+- GS-QA: [arXiv:2502.13196](https://arxiv.org/abs/2502.13196)
+- GGSC compression benchmark: [arXiv:2407.14197](https://arxiv.org/abs/2407.14197),
+  code at [Qi-Yangsjtu/GGSC](https://github.com/Qi-Yangsjtu/GGSC)

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -212,8 +212,9 @@ correspondence between the sets. An A/B of two orbits has no per-frame ground
 truth, since a novel camera path has no photograph, and that is exactly why
 DISTS and CW-SSIM cannot be used on it. A set-level metric can compare the orbit
 renders against the original capture frames without any pose in common, which
-matches the delivery question directly. Does this exported asset still look like
-photographs of this scene?
+looks like the delivery question. Does this exported asset still look like
+photographs of this scene? That framing is what motivated the rest of this
+section, and it does not survive it.
 
 The one measurement available is MUGSQA's, which reports FID at 0.52 Spearman on
 its main set and 0.77 on its additional set, second best of everything it tried
@@ -568,6 +569,13 @@ Treat 0.5 as a reason to distrust close calls, not as an error rate for ours.
 
 DBCNN at 0.88 and GSOQA at 0.77 are trained or cross-validated on the same
 dataset they score. They are not drop-in metrics.
+
+Every render behind the distribution-metric numbers is a JPEG at quality 95.
+That is well below the effects at the coarse end of the ladder and it is shared
+by every configuration, but at the fine end, where the differences approach the
+encoder's own error, some of what those metrics failed to resolve may be the
+encoding rather than the estimator. Any rerun aimed at the fine rungs should
+write PNG.
 
 3DGS-QA reports FAST-VQA at 0.29 while 3DGS-VBench reports 0.93. The two
 datasets contain different distortions and different content, and neither paper

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -108,7 +108,10 @@ the same rate. Nobody has measured that, and the 62% scenes remain the ones to
 worry about.
 
 **The container choice.** SPZ against SOG is a quantisation decision applied to
-a fixed set of Gaussians. GS-QA evaluates SOG, but as a reconstruction *method*
+a fixed set of Gaussians. Measured on one cleaned 250k export (`gaudi_ceiling`,
+224,367 Gaussians): 55.6 MB as PLY, 5.9 MB as SPZ, 2.6 MB as SOG, all carrying
+three SH bands. Whether the 3.3 MB SOG saves costs anything a viewer would see
+is exactly the kind of question the metrics above cannot answer. GS-QA evaluates SOG, but as a reconstruction *method*
 with spherical harmonics removed during training, not as a container applied
 afterwards. Nothing published covers our version of the question.
 

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -95,11 +95,13 @@ an unverified benefit on the other.
 
 **The cleanup threshold.** Filtering at opacity 0.05 removes between 4.9% and
 62% of the Gaussians depending on the scene, and it is not free. Paired testing
-puts the cost at 0.0007 LPIPS on `gaudi_fountain` and 0.0059 on `r2d2_new`, the
-same sign on every frame of both, with PSNR and SSIM agreeing. It was called
-free because the marginal spread is 0.05 and 0.035, which buried it. The cost is
-small enough that a median 28% size saving is still worth paying, but "free" was
-the wrong word and it was reached the wrong way.
+moves LPIPS by 0.0007 on `gaudi_fountain` and 0.0059 on `r2d2_new`, the same
+sign on every frame of both, with PSNR and SSIM agreeing. It was called free
+because the marginal spread is 0.05 and 0.035, which buried it. Whether a median
+28% size saving is worth that is the trade the paired-comparison study exists to
+settle, and this document cannot settle it: movement in an objective metric is
+sensitivity, not a known change in what anyone sees. What is established is that
+"free" was the wrong word and was reached the wrong way.
 
 3DGS-QA measured content-blind random pruning at 25/50/75% and found it degrades
 MOS smoothly. Our filter is attribute-based, targeting Gaussians the model
@@ -183,8 +185,10 @@ gives the variance inflation for the mean. Estimated directly it comes out below
 1 for all three, because the long lags return negative estimates. The longest of
 those rest on 16 to 20 products, and the sample autocorrelation of any series
 sums to -1/2 across all lags by construction, so the far tail is biased down. Clamping every
-negative estimate to zero is the conservative reading. The two bracket the
-answer:
+negative estimate to zero is the more cautious reading. Neither is a bound. The
+positive estimates carry the same downward bias, so the true inflation can sit
+above the clamped value, and at these lags nothing here pins it down. Read the
+two as a sensitivity analysis:
 
 | comparison             | as estimated | negatives to zero | width factor |
 | ---------------------- | ------------ | ----------------- | ------------ |
@@ -192,13 +196,14 @@ answer:
 | prune 0.05, r2d2       | 0.85         | 1.10              | up to 1.05   |
 | seed off to on, gaudi  | 0.76         | 1.31              | up to 1.15   |
 
-For every row except seeding this changes nothing: a 5 to 9% wider interval
-leaves each verdict where it was. Seeding is the exception, and not by a
-comfortable margin either way. Its interval reaches zero at a width factor of
-1.095, which sits between the two bounds: [-0.145, -0.017] under the estimated
-inflation and [-0.166, +0.004] under the conservative one. The row should not be
-read as resolving anything, and the reason is dependence rather than sample
-size.
+At both values every row except seeding keeps its verdict, a 5 to 9% widening
+that changes nothing. That is not the same as showing no verdict can move, since
+the true inflation is not bounded above by either number. Seeding already fails
+at the cautious value, and not by a comfortable margin either way. Its interval
+reaches zero at a width factor of 1.095, which sits between the two: [-0.145,
+-0.017] under the direct estimate and [-0.166, +0.004] under the clamped one.
+The row should not be read as resolving anything, and the reason is dependence
+rather than sample size.
 
 That is a statement about this test, not about seeding. Seeding moves LPIPS from
 0.468 to 0.387 at 10k steps and 0.341 to 0.282 at 30k, and on the full 112-frame
@@ -206,11 +211,16 @@ walkthrough the paired difference is -0.071 against an effective sample size of
 4.6, which is four standard errors from zero. The effect is not in doubt. What
 the five-frame interval could carry is.
 
-Two caveats on the correction itself. The three comparisons measured here are
-the pruning pair on both scenes and the seeding pair on gaudi; the cap and
-`rasterize_mode` rows are assumed to sit inside the same range, which is
-untested. And these autocorrelations come from training views, while the table
-scores held-out ones.
+Three caveats on the correction itself. A dependence-robust interval computed
+from the eval frames alone, block or HAC, is not available at five and seven
+observations: it would need the same long-lag autocorrelations, estimated from
+even less. A sensitivity analysis is the ceiling this design supports, which is
+itself a reason to prefer the export-referenced comparison below, where every
+frame is scored. The three comparisons measured here are the pruning pair on
+both scenes and the seeding pair on gaudi; the cap and `rasterize_mode` rows are
+assumed to sit inside the same range, which is untested. And these
+autocorrelations come from training views, while the table scores held-out
+ones.
 
 Three things fall out.
 

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -304,9 +304,10 @@ standard protocol it returned 0.30.
 
 The rungs to watch are the fine ones, because the section below measures what
 actually separates them: 61 dB on gaudi and 68 dB on r2d2 between the unpruned
-render and the 0.01 rung, 53 and 57 dB at 0.02. Those are not small differences
-so much as absent ones. A metric that resolves a step there with confidence is
-reporting something that is not in the images.
+render and the 0.01 rung, 53 and 57 dB at 0.02. The images there differ, but
+barely. Whether an estimator ought to resolve a difference that small is a
+question about how much difference matters, which nothing in this document
+settles.
 
 | rung    | gaudi FID | gaudi KID x1000 | gaudi CMMD | r2d2 FID | r2d2 KID x1000 | r2d2 CMMD |
 | ------- | --------- | --------------- | ---------- | -------- | -------------- | --------- |
@@ -341,23 +342,26 @@ Steps, with an interval excluding zero marked R:
 The coarse end is unanimous. Every metric resolves 0.05 to 0.1 in both scenes
 and all but one resolves 0.02 to 0.05, with intervals nowhere near zero.
 
-The fine end separates them. FID resolves nothing there, which is the right
-answer. CMMD resolves one step, r2d2 0.01 to 0.02, in the direction of more
-pruning meaning more deviation. KID resolves two, gaudi 0.00392 to 0.01 and
-r2d2 0.01 to 0.02, both negative, both saying pruning moved the render closer to
-the photographs at a rung where the render barely moved at all.
+The fine end does not sort them out. FID resolves nothing there. CMMD resolves
+one step, r2d2 0.01 to 0.02, in the direction of more pruning meaning more
+deviation. KID resolves two, gaudi 0.00392 to 0.01 and r2d2 0.01 to 0.02, both
+negative, both saying pruning moved the render nearer the photographs.
 
-One pair settles it without any appeal to what a viewer would say. On r2d2's
-0.01 to 0.02 step KID reports -0.059 with an interval of [-0.104, -0.019] and
-CMMD reports +0.0069 with [+0.0039, +0.0099]. Same images, same frames, both
-intervals excluding zero, opposite signs. At most one of them is right, and
-nothing about the ladder or about human preference is needed to say so.
+On r2d2's 0.01 to 0.02 step KID reports -0.059 with an interval of
+[-0.104, -0.019] while CMMD reports +0.0069 with [+0.0039, +0.0099]: same
+images, same frames, both excluding zero, opposite signs. That is less damning
+than it first looks. KID measures a polynomial-kernel distance between Inception
+features and CMMD an RBF distance between CLIP features, so a change in the
+images can genuinely shorten one and lengthen the other. Nothing is being
+contradicted. What it does mean is that at most one of them can be tracking any
+single underlying notion of quality, and this data cannot say which, or whether
+either does.
 
-An earlier version of this section had FID committing the same error, resolving
-gaudi's 0.00392 to 0.01 step as an improvement. That was the JPEG encoder rather
-than the metric, and it disappeared when the renders were written losslessly.
-The correction is recorded because it is the same failure the document is about,
-made while writing it: a resolved interval on an artifact.
+An earlier version of this section had FID resolving gaudi's 0.00392 to 0.01
+step as an improvement, and I read that as the metric misbehaving. It was the
+JPEG encoder, and it vanished when the renders were written losslessly. Worth
+recording, because a resolved interval on an artifact is the exact failure this
+document is about, produced while writing it.
 
 #### A flaw in the standard KID protocol
 
@@ -408,26 +412,30 @@ step being free.
 
 #### What to take from this
 
-No opinion scores exist for this ladder, so none of this ranks the three metrics
-by correctness. What it does have is one fact that needs no labels. The renders
-at the fine rungs differ by 53 to 68 dB, measured directly in the section below,
-and two images that close are not different in any way a metric should be able
-to speak confidently about. That is enough to read a resolved interval there as
-a fault rather than as sensitivity.
+No opinion scores exist for this ladder, and nothing here supplies a substitute.
+The fine rungs render 53 to 68 dB apart, which says the images barely differ, and
+it is tempting to read a resolved interval there as a false positive. That
+reading does not hold. The images do differ, so an estimator separating them is
+detecting something real; a narrow interval around a tiny effect is what
+sensitivity looks like. Calling it an error would need an equivalence bound
+declared in advance and an interval that fits inside it, which is the same thing
+this document demands before anyone calls PSNR blind. No such bound exists here.
 
-By that standard FID comes out clean at the fine end, CMMD reports one resolved
-step, and KID reports two. KID's are the awkward ones: both say pruning brought
-the render closer to the photographs, and its disagreement with CMMD on r2d2's
-0.01 to 0.02 step is a flat contradiction between two intervals that both
-exclude zero. The estimator with the cleanest theoretical property at small n
-produced the least trustworthy output, and the reason is that the argument for
-it was about bias while the constraint that actually bites at 112 frames is
-variance.
+So the fine end ranks nobody. FID resolves nothing, CMMD resolves one step, KID
+resolves two, and which behaviour is correct depends on a threshold nobody has
+set.
 
-Set against that, all three resolve the coarse rungs cleanly and agree on
-direction there. If a set-level number is wanted, CMMD is the one to use and the
-frame count has to be held fixed across everything being compared, since FID's
-level alone drifts 12.8 points between 28 and 112 frames.
+What does separate them needs no labels at all, because it is about the
+estimators rather than the images. FID's level falls 12.8 points between 28 and
+112 frames, more than twice the range of the entire ladder, so it cannot be read
+as a number and cannot be compared across differing frame counts. KID returns
+-6.4 at 36 frames, a negative squared distance, which is legal for an unbiased
+estimator and useless for ordering anything. CMMD shows neither pathology. On
+that basis, and only that basis, CMMD is the one to reach for, with the frame
+count held fixed across everything being compared.
+
+All three resolve the coarse rungs cleanly and agree on direction there, which
+is the regime where the choice of metric stops mattering.
 
 The larger conclusion is that this line of attack was aimed at a problem we do
 not have. Set-level metrics earn their keep when nothing corresponds between the
@@ -493,12 +501,14 @@ Pruning at 0.1 leaves 446k and 324k, cuts of 55% and 68%, and moves it by 0.020
 and 0.054 at around 32 dB. The r2d2 cell at 0.1 is the only one that looks like
 a real cost.
 
-The fine rungs land somewhere more useful than "small". At 0.01 the two renders
-differ by 61 dB on gaudi and 68 dB on r2d2, which is not a small difference so
-much as no difference at all. Whatever those rungs cost, it is not something a
-viewer could be shown. That is a defensible
-basis for setting the shipping threshold at 0.05, and it holds regardless of
-what the photographs contain or where the tourists were standing.
+The fine rungs come out very small indeed: 61 dB on gaudi and 68 dB on r2d2 at
+0.01. That says nothing about the threshold actually being shipped. The step
+from 0.01 to 0.05 is where almost all of the deviation and almost all of the
+size saving happen, and 0.0032 and 0.0078 LPIPS at 42 dB is a magnitude, not a
+verdict. What this replaces is the previous state of affairs, where the number
+was unmeasured and the threshold was set by assertion. Whether it is small
+enough to ship is still the study's question, now asked about a known
+quantity.
 
 Two things it still cannot do. The unpruned export wins by construction, so this
 can never report that pruning improved anything, only how far it moved. And a

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -560,6 +560,30 @@ frames are consecutive poses along a walkthrough, so neighbouring views share
 most of their content, and an i.i.d. resample treats them as independent
 observations and returns an interval narrower than the data supports.
 
+The wraparound is worth its own check, because these paths are not loops.
+Wrapping is what makes the scheme circular in the sense of Politis and Romano:
+starts run over the whole sequence and a block that runs off the end continues
+from the front, so every frame sits in exactly L blocks. Stopping the starts at
+n minus L instead removes the artificial join but gives the frames near either
+end fewer chances to appear than the ones in the middle, which is its own bias.
+Neither choice is free.
+
+Here the join really is artificial. Gaudi's first and last camera positions are
+28.5 median frame steps apart, 61% of the scene's extent, and r2d2's are 9.1
+steps and 37%, so the last frame is nowhere near the first on either capture. At
+block length 20 that splice is common rather than rare: 64% of replicates
+contain one, about one join per replicate on both scenes.
+
+It changes the widths and none of the verdicts. Rerunning both tables with
+starts restricted so no block spans the end moves interval widths between 25%
+narrower and 14% wider, and four cells swap which construction excludes zero,
+all of them cells that carry no R under either scheme. Every step marked R keeps
+it under both constructions with the wraparound removed. The LPIPS ladder is the
+same story: widths move by 14% down to 4% up, and the smallest gap between
+neighbouring rungs stays above 3.6 times the wider of the two intervals either
+way. The tables keep the circular scheme, which is the standard one, and the
+answer to the objection is that it does not decide anything here.
+
 Enough of the procedure to rerun it. Each replicate draws ceil(n/L) block
 starts uniformly from 0 to n-1, takes L consecutive indices from each with
 wraparound past the end of the sequence, concatenates them and truncates back

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -205,22 +205,34 @@ reaches zero at a width factor of 1.095, which sits between the two: [-0.145,
 The row should not be read as resolving anything, and the reason is dependence
 rather than sample size.
 
-That is a statement about this test, not about seeding. Seeding moves LPIPS from
-0.468 to 0.387 at 10k steps and 0.341 to 0.282 at 30k, and on the full 112-frame
-walkthrough the paired difference is -0.071 against an effective sample size of
-4.6, which is four standard errors from zero. The effect is not in doubt. What
-the five-frame interval could carry is.
+That is a statement about this test, not about seeding, and the full walkthrough
+settles it without needing any of the estimates above. Rendering both
+configurations over all 112 frames and moving-block bootstrapping the mean gives
+-0.0714 with [-0.098, -0.045] at block length 20 and [-0.102, -0.041] at 40,
+excluding zero at every block length tried. That interval needs no effective
+sample size and no autocorrelation sum: the resampling carries the dependence
+itself. The same treatment resolves both pruning comparisons at every block
+length as well, at +0.00054 [+0.00029, +0.00078] on gaudi and +0.00430
+[+0.00395, +0.00463] on r2d2. Seeding also moves LPIPS from 0.468 to 0.387 at
+10k steps and 0.341 to 0.282 at 30k. The effect is not in doubt. What the
+five-frame interval could carry is.
 
-Three caveats on the correction itself. A dependence-robust interval computed
-from the eval frames alone, block or HAC, is not available at five and seven
-observations: it would need the same long-lag autocorrelations, estimated from
-even less. A sensitivity analysis is the ceiling this design supports, which is
-itself a reason to prefer the export-referenced comparison below, where every
-frame is scored. The three comparisons measured here are the pruning pair on
-both scenes and the seeding pair on gaudi; the cap and `rasterize_mode` rows are
-assumed to sit inside the same range, which is untested. And these
-autocorrelations come from training views, while the table scores held-out
-ones.
+Which points at the fix rather than the caveat. Every one of these comparisons
+has a full walkthrough available, so the eval-split table is a five-frame
+estimate of something 112 frames can measure directly. The block-bootstrapped
+full-sequence figures are the ones to trust, with the standing caveat that they
+score training views and so understate every degradation.
+
+Three caveats. A dependence-robust interval computed from the eval frames alone,
+block or HAC, is not available at five and seven observations: it would need the
+same long-lag autocorrelations, estimated from even less. That is why the
+correction to the table is a sensitivity analysis while the full-sequence
+figures above are a block bootstrap, and why the second is the one to lean on.
+The three comparisons measured here are the pruning pair on both scenes and the
+seeding pair on gaudi; the cap and `rasterize_mode` rows have no full-sequence
+figure and are assumed to sit inside the same range, which is untested. And all
+of this, autocorrelations and block intervals alike, comes from training views
+while the table scores held-out ones.
 
 Three things fall out.
 

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -145,9 +145,11 @@ LPIPS, mean paired difference with a 95% interval, and how often the difference
 kept its sign across frames. These intervals treat the frames as independent,
 which the section below shows is wrong for a walkthrough. Whether it is wrong
 here is a question about spacing, so it was measured rather than argued. See
-"How independent are the eval frames" after the table: for most rows the answer
-is that the intervals are 5 to 9% too narrow, and for the seeding row it is that
-the interval should not be read as resolving anything.
+"How independent are the eval frames" after the table. Three of these eight rows
+were measured. On the two pruning rows at 0.05 the intervals come out 5 to 9%
+too narrow; on the seeding row the interval should not be read as resolving
+anything. The other five rows carry no measurement of their own and are assumed
+to sit in the same range, which is untested.
 
 | Comparison | n | Mean diff | 95% CI | Paired SD | Marginal SD | Same sign |
 |---|---|---|---|---|---|---|
@@ -529,10 +531,16 @@ correlated neighbours inflate, while a statistic computed from the whole
 resampled set absorbs the correlation. So block resampling matters a great deal
 for the export-referenced LPIPS ladder below and barely at all for this section.
 
-It does not overturn the LPIPS ladder. Every rung there stays separated from its
-neighbours by more than the width of either interval, at the widest block length
-tried. The LPIPS widths were still climbing at 20, by 16 to 22% over block length
-10, so they are a lower bound rather than a converged answer.
+It does not overturn the LPIPS ladder, and the widths do not run away either.
+At 20 they were still climbing, 16 to 22% over block length 10, which left the
+question of where they stop. Pushing the ladder out to block lengths of 30, 40,
+60, 80 and 100 answers it: every rung peaks at 40, 7 to 17% wider than at 20,
+and falls back after. That is forced by the resampling rather than by the data.
+A wrapped block of length L covers a fixed fraction of the sequence whatever its
+start, so as L approaches n every replicate converges on the full-sample mean
+and the interval has to collapse. The reported intervals stay at block length
+20, where the set-level metrics were also measured, and 40 is the honest worst
+case.
 
 FID needed a second fix for an unrelated reason. Its bootstrap had been running
 25 replicates, because the textbook Frechet term needs the square root of a
@@ -739,10 +747,12 @@ intervals overlaps. The identity rung returns exactly zero with infinite PSNR,
 which is a fact rather than a
 calibration hope. Where FID and KID both invert on both scenes and the three of
 them together resolve one fine step out of eight, this separates all five rungs
-in both scenes, and the intervals are narrow enough that the separation is not
-close. CMMD does better than the other two at the fine end: it orders both
-ladders correctly, and it resolves r2d2's 0.01 to 0.02 step, which KID also
-resolves in the opposite direction.
+in both scenes, and the separation holds at the block length where the intervals
+are widest. At 40 the tightest neighbouring gap is 2.6 times the wider of the
+two intervals on gaudi and 3.2 times on r2d2, and no pair comes closer than that
+at any block length from 1 to 100. CMMD does better than the other two at the
+fine end: it orders both ladders correctly, and it resolves r2d2's 0.01 to 0.02
+step, which KID also resolves in the opposite direction.
 
 The reason is not that LPIPS is a better metric than CMMD. It is that the
 comparison is paired at the level of individual frames against an exact
@@ -844,11 +854,12 @@ The proposed experiment, in order:
    construction. That leaves DOVER, VSFA, FAST-VQA and Q-Align, which score each
    orbit on its own. DISTS and CW-SSIM can only be tested on held-out frames
    where a real photo exists, which is a different experiment against different
-   stimuli than the one a viewer judged. Score every pair the rater was
-   self-consistent on, including the ones they called identical both times.
-   Dropping those would validate a candidate on the pairs that were easy to
-   call and then wire it in for the close ones, which are the pairs it exists
-   to settle. A repeated "no difference" is a label like any other, so require
+   stimuli than the one a viewer judged. Score a pair only when all three of its
+   showings gave the same response, which is the same bar step 2 sets, and score
+   every pair that clears it, including the ones called identical all three
+   times. Dropping those would validate a candidate on the pairs that were easy
+   to call and then wire it in for the close ones, which are the pairs it exists
+   to settle. A unanimous "no difference" is a label like any other, so require
    the metric to reproduce it: fit a deadband on the selection set wide enough
    to contain the pairs called identical, then on the held-out set ask the
    preference pairs to fall outside the band with the correct sign and the

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -110,10 +110,11 @@ worry about.
 **The container choice.** SPZ against SOG is a quantisation decision applied to
 a fixed set of Gaussians. Measured on one cleaned 250k export (`gaudi_ceiling`,
 224,367 Gaussians): 55.6 MB as PLY, 5.9 MB as SPZ, 2.6 MB as SOG, all carrying
-three SH bands. Whether the 3.3 MB SOG saves costs anything a viewer would see
-is exactly the kind of question the metrics above cannot answer. GS-QA evaluates SOG, but as a reconstruction *method*
-with spherical harmonics removed during training, not as a container applied
-afterwards. Nothing published covers our version of the question.
+three SH bands. Whether the 3.3 MB that SOG saves over SPZ costs anything a
+viewer would see is exactly the kind of question the metrics above cannot
+answer. GS-QA evaluates SOG, but as a reconstruction *method* with spherical
+harmonics removed during training, not as a container applied afterwards.
+Nothing published covers our version of the question.
 
 **The frame-count experiment.** Invalid, and not for a subtle reason. The design
 held a fixed set of 11 source frames out of every configuration so the two runs
@@ -229,20 +230,29 @@ depends on the model being scored, so evaluating two configurations at the same
 small n does not cancel it. Chong and Forsyth propose extrapolating to infinite
 samples to get around this; common practice is tens of thousands of images.
 
-KID is the answer to that. It replaces the Fréchet distance with a
+KID answers that on paper. It replaces the Fréchet distance with a
 polynomial-kernel MMD that has an unbiased estimator and assumes nothing about
 the distribution, which is what makes it usable at small n. Variance still falls
 with sample size, but the bias does not depend on it, so a comparison at fixed
-small n means something. Between the two, KID is the one to reach for here.
+small n should mean something. On that reasoning I expected KID to be the one to
+reach for. The measurements below disagree, and the reason is variance rather
+than bias.
 
 CMMD is the stronger version of the same idea. Jayasumana et al. argue FID fails
 on three counts at once, with Inception features too narrow for varied content,
 a normality assumption that does not hold, and poor sample complexity, and show
 it contradicting human raters and reordering itself as sample size changes.
 Their replacement keeps the MMD but swaps in CLIP embeddings and a Gaussian RBF
-kernel. Unbiased, distribution-free, sample efficient, and available as
-`clip-mmd`. If the goal is a feature-based distributional metric, this is the
-current best version of it.
+kernel: distribution-free, sample efficient, and available as `clip-mmd`.
+
+One detail matters before leaning on the unbiasedness argument twice. The
+estimator Google published, which `clip-mmd` vendors verbatim, is the
+minimum-variance form of Gretton et al.'s Eq. (5). It averages the kernel matrix
+including its diagonal, so it is the biased V-statistic, not the unbiased one
+that makes KID safe at small n. The docstring argues the two are almost
+identical, citing the proof of Lemma 6 in the same paper, and for ranking
+configurations at a fixed sample size the difference does not bite. KID is still
+the one with the cleaner claim.
 
 Three cautions before treating any of them as an answer.
 
@@ -265,11 +275,185 @@ The natural reference set is our own capture frames, which contain the tourists.
 A model that correctly drops a transient gets penalised for not matching, the
 same bias already documented for the held-out frames.
 
-The honest recommendation is to test KID or CMMD as a companion, not a
-replacement, and to put it through the same ladder as everything else. Render a
-few hundred orbit frames per configuration, which costs nothing, use the capture
-frames as the reference set, and require it to order a degradation ladder
-correctly before asking it anything harder.
+### What happened when I ran them
+
+I ran all three rather than leaving the question open. Every training view of
+each configuration, rendered at full resolution and compared against the capture
+photographs, on two scenes. CMMD uses CLIP ViT-L/14-336 features with a single
+bicubic resize to 336 by 336; FID and KID use the standard 2048-d Inception
+pool3 features. Uncertainty comes from bootstrap replicates that resample the
+frame indices once per replicate and recompute the *difference* under that
+shared resampling. The ladder is the opacity pruning threshold at 0, 0.00392,
+0.01, 0.02, 0.05 and 0.1.
+
+The first rung is a free calibration check. Splatfacto already culls at an
+alpha of 0.005 during training, so asking for 0.00392 afterwards removes
+nothing. Both scenes render byte-identical images to the unpruned run and the
+two configurations are the same model. FID and CMMD both return exactly zero
+with a zero-width interval, which is what a correctly paired bootstrap has to
+return on identical inputs and what independent bootstrapping of the two
+estimates would not have returned. KID returned 0.30 instead, for reasons that
+turned out to be worth a section of their own.
+
+#### FID
+
+| threshold | gaudi FID | r2d2 FID |
+| --------- | --------- | -------- |
+| 0         | 62.19     | 35.59    |
+| 0.00392   | 62.19     | 35.59    |
+| 0.01      | 62.11     | 35.59    |
+| 0.02      | 62.09     | 35.52    |
+| 0.05      | 62.91     | 37.04    |
+| 0.1       | 67.56     | 47.62    |
+
+| step           | gaudi ΔFID [95% CI]        | r2d2 ΔFID [95% CI]           |
+| -------------- | -------------------------- | ---------------------------- |
+| 0 → 0.00392    | +0.000 [+0.000, +0.000]    | +0.000 [+0.000, +0.000]      |
+| 0.00392 → 0.01 | -0.069 [-0.143, -0.014]    | -0.001 [-0.031, +0.024]      |
+| 0.01 → 0.02    | -0.053 [-0.183, +0.102]    | -0.054 [-0.140, +0.033]      |
+| 0.02 → 0.05    | +0.880 [+0.289, +1.491]    | +1.637 [+1.260, +2.137]      |
+| 0.05 → 0.1     | +5.144 [+4.101, +6.286]    | +11.856 [+10.456, +13.232]   |
+
+FID inverts at the fine end in both scenes and, on gaudi, does so with an
+interval that excludes zero: pruning at 0.01 is confidently ranked better than
+not pruning at all. r2d2 shows the same dip without resolving it. Confidently
+ranking a degradation as an improvement in one scene and not the other is the
+failure mode to worry about, because nothing in the output marks which scene you
+are in.
+
+The sample-size bias is the part to take seriously. The unpruned gaudi run reads
+75.12, 69.38, 66.64 and 62.19 at 28, 56, 84 and 112 frames, and the unpruned
+r2d2 run reads 43.20, 38.42, 37.31 and 35.59 at 36, 73, 110 and 147. Both fall
+monotonically as frames are added, exactly the behaviour Chong and Forsyth
+describe. On gaudi that drift spans 12.9 FID points against a ladder whose whole
+range is 5.4. The number is therefore uninterpretable on its own, and comparing
+two configurations evaluated at different frame counts would be meaningless. The
+steps above survive only because the shared bootstrap cancels the part of the
+bias the two runs have in common.
+
+#### KID, and a flaw in the standard protocol
+
+KID needed fixing before it could be read. The usual protocol averages the
+unbiased MMD over random subsets of the two feature sets, and my first run drew
+those subsets independently for each configuration. On the byte-identical rung
+that produced 15.76 against 16.07, a difference of 0.30 where the truth is
+exactly zero, against a full ladder spanning only 1.7. The sampling noise was
+larger than every step at the fine end and the pairing could not cancel it,
+because the two runs never saw the same subsets. The estimator is unbiased on
+the whole set, so I dropped the subsetting and computed it there. The identical
+rung then returned exactly zero and the frame bootstrap became the only source
+of uncertainty. Anyone comparing two configurations with KID should do the same,
+or at minimum share the subset draws between them.
+
+| threshold | gaudi KID x1000 | r2d2 KID x1000 |
+| --------- | --------------- | -------------- |
+| 0         | 16.103          | 4.034          |
+| 0.00392   | 16.103          | 4.034          |
+| 0.01      | 16.017          | 4.030          |
+| 0.02      | 15.965          | 3.955          |
+| 0.05      | 16.063          | 4.485          |
+| 0.1       | 17.682          | 8.232          |
+
+KID orders the ladder worse than CMMD does. Both scenes rank 0.05 below the
+unpruned run, and each contains one resolved decrease at the fine end, gaudi at
+the 0.01 rung and r2d2 at the 0.02 rung, so KID reports pruning as a small
+improvement with confidence in both. Only the step from 0.05 to 0.1 separates
+cleanly in both scenes.
+
+Sample count hits KID hardest. A single draw at 36 frames puts every r2d2 rung
+at roughly -6.6, a negative squared distance, which the unbiased estimator is
+free to produce but which no longer supports an ordering. The same rungs read
++4.0 at 147 frames. The estimator is unbiased in expectation, and that is not
+the same as usable from one draw at this size.
+
+#### CMMD
+
+| threshold | gaudi_fountain (n=112) | r2d2_new (n=147) |
+| --------- | ---------------------- | ---------------- |
+| 0         | 0.3661                 | 0.6176           |
+| 0.00392   | 0.3661                 | 0.6176           |
+| 0.01      | 0.3670                 | 0.6196           |
+| 0.02      | 0.3664                 | 0.6258           |
+| 0.05      | 0.3819                 | 0.7008           |
+| 0.1       | 0.4327                 | 0.9505           |
+
+Past that the two scenes disagree. r2d2 orders the ladder correctly. gaudi does
+not, scoring 0.02 below 0.01, so the ordering inverts at the fine end.
+
+| step             | gaudi ΔCMMD [95% CI]        | r2d2 ΔCMMD [95% CI]         |
+| ---------------- | --------------------------- | --------------------------- |
+| 0 → 0.00392      | +0.0000 [+0.0000, +0.0000]  | +0.0000 [+0.0000, +0.0000]  |
+| 0.00392 → 0.01   | +0.0011 [-0.0010, +0.0030]  | +0.0020 [-0.0001, +0.0042]  |
+| 0.01 → 0.02      | -0.0008 [-0.0037, +0.0017]  | +0.0062 [+0.0008, +0.0114]  |
+| 0.02 → 0.05      | +0.0155 [+0.0108, +0.0210]  | +0.0741 [+0.0638, +0.0854]  |
+| 0.05 → 0.1       | +0.0511 [+0.0409, +0.0615]  | +0.2532 [+0.2229, +0.2870]  |
+
+The coarse steps resolve in both scenes with intervals well clear of zero. The
+finest step resolves in neither.
+
+The comparison worth putting weight on is the one the paired test already
+answered. Pruning at 0.05 against no pruning gives +0.0158 on gaudi with an
+interval of [0.0108, 0.0213], and +0.0833 on r2d2 with [0.0721, 0.0955]. Both
+exclude zero, and both agree in sign with the paired LPIPS results of +0.0007
+and +0.0059. On this comparison a set-level distribution metric and a per-frame
+perceptual one reach the same verdict, which is worth something given that they
+are not even looking at the same frames.
+
+Sample size stays a problem. The unpruned gaudi run scores 0.3597 at 28 frames,
+0.3883 at 56, 0.3669 at 84 and 0.3662 at 112. The level wanders by more than the
+0.0158 effect it is being asked to measure, and at 28 frames the fine rungs sit
+below the unpruned run. This is the sample-size instability Jayasumana et al.
+document for FID, reappearing in their own replacement at the sample counts a
+single capture provides. The coarse ordering survives it. The fine ordering does
+not.
+
+Three limits apply to all of the above. These are training views, which the
+model was fit to, so they understate every degradation. The paired LPIPS numbers
+they are being compared against came from the five and seven held-out frames
+instead, so agreement between the two is agreement about the configurations and
+not about the same measurement. And an interval spanning zero means the test
+could not resolve that step at this sample size, which is not the same as the
+step being free.
+
+#### What to take from this
+
+Pruning at 0.05 against no pruning is the one comparison here with an
+independent answer, so it is the one to judge them on:
+
+| measurement           | gaudi_fountain              | r2d2_new                    |
+| --------------------- | --------------------------- | --------------------------- |
+| paired LPIPS, held out | +0.0007 [+0.0004, +0.0010] | +0.0059 [+0.0040, +0.0080]  |
+| ΔFID                  | +0.761 [+0.241, +1.337]     | +1.591 [+1.171, +2.073]     |
+| ΔKID x1000            | -0.023 [-0.426, +0.415]     | +0.505 [+0.156, +0.929]     |
+| ΔCMMD                 | +0.0158 [+0.0108, +0.0213]  | +0.0833 [+0.0721, +0.0955]  |
+
+FID and CMMD both resolve it in both scenes and agree with the paired result.
+KID resolves only r2d2, the scene where the effect is eight times larger, and
+misses gaudi entirely.
+
+None of the three orders the whole ladder correctly, though. Each ranks at least
+one pruned configuration above the unpruned original. What separates them is
+whether they do it with confidence: CMMD's inversion sits inside an interval that
+spans zero, while FID and KID both produce a resolved step in the wrong
+direction. A metric that fails to resolve a step is far less dangerous than one
+that resolves it backwards.
+
+That puts CMMD first, FID second and useful as long as its level is never read
+as a number, and KID last. The ordering inverts what the sample-size argument
+predicted, because that argument was about bias while the thing breaking these
+estimators at roughly 100 frames is variance. KID has the cleanest bias property
+and the worst noise.
+
+The result to be most careful with is the easiest one. This test gave all three
+metrics the friendliest setup available: identical poses across configurations,
+a reference set photographed from those same poses, and training views the model
+had already fit. The case that motivated the question, comparing two exported
+assets along an orbit with no photograph anywhere near the camera path, removes
+every one of those advantages. A metric that inverts a ladder under these
+conditions has not earned that harder job. Use CMMD as a companion to the paired
+per-frame tests, keep the frame count fixed across everything being compared,
+and treat a single set-level number as a claim about a distribution rather than
+about what anyone sees.
 
 ## What to measure instead
 

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -297,7 +297,9 @@ advance with the whole interval inside it.
 ## Would FID or KID do better?
 
 Worth separating the premise first: LPIPS is not one of the metrics that works.
-It scored 0.41, 0.34 and 0.51 in the three studies, at or below PSNR every time.
+It scored 0.41, 0.34 and 0.51 in the three studies. Two of those report PSNR as
+well, and LPIPS lands 0.11 below it in MUGSQA and 0.01 above it in 3DGS-VBench,
+so it buys nothing over the metric it was meant to improve on.
 What worked was DISTS at 0.73 and the no-reference video models above 0.93. The
 dividing line is not deep features against hand-built ones, since LPIPS and
 DISTS are both deep-feature metrics separated by 0.4 in correlation.

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -39,12 +39,16 @@ They agree on the part that matters here: PSNR, SSIM and LPIPS all land near 0.5
 or below, and none of the three separates itself from the other two.
 
 The papers also report Kendall correlation, which converts to something more
-concrete. Ignoring ties, a metric with Kendall tau of t orders a random pair of
-stimuli the way a human would about (1+t)/2 of the time. On 3DGS-VBench that
-puts PSNR at 68%, LPIPS at 68% and DISTS at 76%. On 3DGS-QA, LPIPS drops to 64%.
-A coin flip is 50%. When we compare two configurations and one wins on LPIPS,
-the odds that a viewer agrees are closer to two in three than to a settled
-result.
+concrete. Ignoring ties, a metric with Kendall tau of t ranks a random pair of
+stimuli the way the averaged panel ranked them about (1+t)/2 of the time. On
+3DGS-VBench that puts PSNR at 68%, LPIPS at 68% and DISTS at 76%. On 3DGS-QA,
+LPIPS drops to 64%. A coin flip is 50%.
+
+Read that as agreement with a mean opinion score, not with any individual
+viewer. Per-viewer agreement is lower, since the panel average smooths out
+disagreement between people, and none of these papers reports the subject-level
+numbers that would pin it down. Either way, a metric that reproduces the panel's
+ordering two times in three is not settling a close call.
 
 ### What each study degraded
 
@@ -118,28 +122,52 @@ these models, so the numbers appear to be off-the-shelf pretrained weights
 applied to rendered videos. That is worth confirming against their code before
 leaning on it.
 
-If it holds, the recommendation is cheap to adopt. These models take a video,
-need no reference, and we already render orbit videos with `ns-render`. The
-change is one more step after export, not a new benchmark.
+If it holds, adopting it is cheap. These models take a video, need no reference,
+and we already render orbit videos with `ns-render`. The change is one more step
+after export, not a new benchmark.
+
+Adopting it on the strength of separation alone would repeat the mistake this
+document is about. A metric that moves when the configuration changes has shown
+sensitivity, and sensitivity is what LPIPS already has. What we need is
+agreement with a viewer, which takes stimuli whose perceptual ordering is
+established before the metric is asked about them.
 
 The proposed experiment, in order:
 
-1. Run DOVER on the orbit renders from the cap_max sweep already on disk. Four
-   configurations, one scene, no new training. If DOVER separates them where
-   PSNR and SSIM did not, the metric earns its place.
-2. Extend to the cleanup threshold sweep, which is the decision with the widest
-   per-scene spread and the least published coverage.
-3. Only then consider generating our own stimuli. MUGSQA covers the input axes
-   and released its data, so the gap worth filling is attribute-based pruning
-   and container quantisation at fixed training, which is a much smaller build
-   than a full synthetic benchmark.
+1. **Transfer check.** Build a ladder on one of our own scenes where the
+   ordering is not in doubt: training truncated at 2k, 5k, 10k and 30k steps, or
+   pruning at 25/50/75%, degradations large enough that anyone watching the
+   orbits agrees which is worse. Require DOVER to reproduce that order. Passing
+   shows the published 0.94 survives contact with our content and capture style;
+   it does not yet show the metric is useful on close calls. Failing kills it
+   outright, which is why this comes first and costs nothing.
+2. **The contested pairs.** Take the decisions we cannot currently settle, at
+   most a handful: cap_max 250k against 500k, cleanup at 0.05 against raw on a
+   scene where the filter takes 60%, 212 training views against 424. Render
+   orbits, present each pair side by side in randomised order without labels,
+   and record a forced choice. One rater is thin evidence, and it is still the
+   only direct evidence about the decisions we actually make; a published
+   correlation on someone else's stimuli is not a substitute.
+3. **Adopt or fall back.** If DOVER agrees with the forced choices, wire it in
+   after export and report it alongside `ns-eval`. If it disagrees, DISTS (0.73)
+   and CW-SSIM (0.74) are the next candidates and cost almost nothing to try. If
+   nothing agrees, the honest conclusion is that these calls are not
+   metric-decidable and we should pick on file size, which we can measure.
+4. **Build stimuli only if 1 to 3 leave a real gap.** MUGSQA covers the input
+   axes and released its data, so what would remain is attribute-based pruning
+   and container quantisation at fixed training. That is a much smaller build
+   than a full synthetic benchmark, and it needs its own subjective scores to be
+   worth anything, which is the expensive part.
 
 ## Caveats
 
-The correlations above are pooled across content. Predicting an absolute opinion
-score across 15 object types is harder than ranking two settings within one
-scene, so 0.5 is a lower bound on how much of our problem the metrics miss, not
-a direct estimate of how often our A/B comparisons are wrong.
+The correlations above are pooled across content, and our comparisons are not.
+Pooling mixes in differences between object types that have nothing to do with
+tuning, and the per-distortion breakdowns in both 3DGS-QA and MUGSQA do come out
+higher than the pooled figure, so a within-scene comparison may well be easier
+than 0.5 suggests. It may also be harder, because the settings we compare sit
+much closer together than the stimuli in these datasets. Nobody has measured it.
+Treat 0.5 as a reason to distrust close calls, not as an error rate for ours.
 
 DBCNN at 0.88 and GSOQA at 0.77 are trained or cross-validated on the same
 dataset they score. They are not drop-in metrics.

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -141,10 +141,11 @@ the differences directly changes several verdicts.
 
 LPIPS, mean paired difference with a 95% interval, and how often the difference
 kept its sign across frames. These intervals treat the frames as independent,
-which the section below shows is wrong for a walkthrough. It holds here because
-these are held-out eval frames, and nerfstudio's fraction split takes them as
-the complement of an evenly spaced training set: 23 frames apart on gaudi and 22
-on r2d2, further apart than the correlation length measured below.
+which the section below shows is wrong for a walkthrough. Whether it is wrong
+here is a question about spacing, so it was measured rather than argued. See
+"How independent are the eval frames" after the table: for most rows the answer
+is that the intervals are 5 to 9% too narrow, and for the seeding row it is that
+the interval should not be read as resolving anything.
 
 | Comparison | n | Mean diff | 95% CI | Paired SD | Marginal SD | Same sign |
 |---|---|---|---|---|---|---|
@@ -156,6 +157,60 @@ on r2d2, further apart than the correlation length measured below.
 | prune 0.1, gaudi | 5 | +0.0042 | [+0.003, +0.005] | 0.0009 | 0.050 | 5/5 |
 | prune 0.05, r2d2 | 7 | +0.0059 | [+0.004, +0.008] | 0.002 | 0.035 | 7/7 |
 | prune 0.1, r2d2 | 7 | +0.0373 | [+0.029, +0.046] | 0.010 | 0.038 | 7/7 |
+
+### How independent are the eval frames
+
+nerfstudio's fraction split takes the eval frames as the complement of an evenly
+spaced training set, which lands them at 23, 46, 69, 92 and 115 on gaudi and
+about 22 apart on r2d2. Spacing is not independence, so measure the correlation
+of the thing being averaged: the paired per-frame LPIPS difference, computed on
+every frame of the walkthrough in capture order.
+
+It depends on which comparison, and by more than the spacing does:
+
+| comparison            | rho at lag 1 | rho at eval spacing | below 0.1 at lag | ESS / n    |
+| --------------------- | ------------ | ------------------- | ---------------- | ---------- |
+| prune 0.05, gaudi     | 0.79         | +0.11 (lag 23)      | 31               | 6.5 / 112  |
+| prune 0.05, r2d2      | 0.61         | -0.02 (lag 21)      | 5                | 25.8 / 147 |
+| seed off to on, gaudi | 0.97         | +0.19 (lag 23)      | 25               | 4.6 / 112  |
+
+Seeding is the slowly varying one, which fits what it does: it changes how well
+the whole reconstruction resolves, so neighbouring views move together. Pruning
+on r2d2 is nearly white by lag 5.
+
+Summing the autocorrelation over the actual pairwise lags of the eval frames
+gives the variance inflation for the mean. Estimated directly it comes out below
+1 for all three, because the long lags return negative estimates. The longest of
+those rest on 16 to 20 products, and the sample autocorrelation of any series
+sums to -1/2 across all lags by construction, so the far tail is biased down. Clamping every
+negative estimate to zero is the conservative reading. The two bracket the
+answer:
+
+| comparison             | as estimated | negatives to zero | width factor |
+| ---------------------- | ------------ | ----------------- | ------------ |
+| prune 0.05, gaudi      | 0.86         | 1.18              | up to 1.09   |
+| prune 0.05, r2d2       | 0.85         | 1.10              | up to 1.05   |
+| seed off to on, gaudi  | 0.76         | 1.31              | up to 1.15   |
+
+For every row except seeding this changes nothing: a 5 to 9% wider interval
+leaves each verdict where it was. Seeding is the exception, and not by a
+comfortable margin either way. Its interval reaches zero at a width factor of
+1.095, which sits between the two bounds: [-0.145, -0.017] under the estimated
+inflation and [-0.166, +0.004] under the conservative one. The row should not be
+read as resolving anything, and the reason is dependence rather than sample
+size.
+
+That is a statement about this test, not about seeding. Seeding moves LPIPS from
+0.468 to 0.387 at 10k steps and 0.341 to 0.282 at 30k, and on the full 112-frame
+walkthrough the paired difference is -0.071 against an effective sample size of
+4.6, which is four standard errors from zero. The effect is not in doubt. What
+the five-frame interval could carry is.
+
+Two caveats on the correction itself. The three comparisons measured here are
+the pruning pair on both scenes and the seeding pair on gaudi; the cap and
+`rasterize_mode` rows are assumed to sit inside the same range, which is
+untested. And these autocorrelations come from training views, while the table
+scores held-out ones.
 
 Three things fall out.
 
@@ -475,7 +530,10 @@ Chong and Forsyth describe. The drift is 12.8 points on gaudi against a ladder
 whose whole range is 5.4, so the number cannot be read on its own and two
 configurations evaluated at different frame counts cannot be compared at all.
 The steps above survive because the shared bootstrap cancels the part of that
-bias the two runs have in common.
+bias the two runs have in common. How much that is stays unmeasured. The null
+rung shows the cancellation is exact when the two configurations are identical,
+which is the easy case; the bias depends on the feature distribution, and two
+configurations that differ do not have to share all of it.
 
 KID is worse in a different way. A single draw at 36 frames puts the r2d2 run at
 -6.4, a negative squared distance, which an unbiased estimator is entitled to
@@ -516,7 +574,8 @@ FID's absolute level falls 12.8 points between 28 and 112 frames, more than
 twice the range of the whole ladder, so it cannot be read as a number and two
 configurations scored at different frame counts cannot be compared at all. The
 paired steps survive because the shared bootstrap cancels the part of that drift
-the two runs have in common. Nothing rescues the level.
+the two runs have in common, with the caveat above on how much that is. Nothing
+rescues the level.
 
 The second is discriminability under matched samples. Each metric's own
 bootstrap supplies its sampling deviation, on the same frames under the same

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -321,12 +321,12 @@ settles.
 
 | rung    | gaudi FID | gaudi KID x1000 | gaudi CMMD | r2d2 FID | r2d2 KID x1000 | r2d2 CMMD |
 | ------- | --------- | --------------- | ---------- | -------- | -------------- | --------- |
-| 0       | 62.68     | 16.553          | 0.4553     | 35.83    | 4.214          | 0.6908    |
-| 0.00392 | 62.68     | 16.553          | 0.4553     | 35.83    | 4.214          | 0.6908    |
-| 0.01    | 62.65     | 16.515          | 0.4563     | 35.82    | 4.209          | 0.6911    |
-| 0.02    | 62.63     | 16.460          | 0.4562     | 35.78    | 4.150          | 0.6984    |
-| 0.05    | 63.33     | 16.507          | 0.4696     | 37.29    | 4.649          | 0.7730    |
-| 0.1     | 68.10     | 18.200          | 0.5312     | 47.86    | 8.384          | 1.0171    |
+| 0       | 62.68     | 16.553          | 0.4554     | 35.83    | 4.214          | 0.6907    |
+| 0.00392 | 62.68     | 16.553          | 0.4554     | 35.83    | 4.214          | 0.6907    |
+| 0.01    | 62.65     | 16.515          | 0.4563     | 35.82    | 4.209          | 0.6913    |
+| 0.02    | 62.63     | 16.460          | 0.4563     | 35.78    | 4.150          | 0.6984    |
+| 0.05    | 63.33     | 16.507          | 0.4695     | 37.29    | 4.649          | 0.7730    |
+| 0.1     | 68.10     | 18.200          | 0.5312     | 47.86    | 8.384          | 1.0172    |
 
 All three pass the null rung exactly, returning zero with a zero-width interval
 on the pair that renders byte-identical images.
@@ -337,17 +337,17 @@ Steps, with an interval excluding zero marked R:
 | --------------- | ------------------------- | ------------------------- | ---------------------------- |
 | 0 → 0.00392     | +0.000 [+0.000, +0.000]   | +0.000 [+0.000, +0.000]   | +0.0000 [+0.0000, +0.0000]   |
 | 0.00392 → 0.01  | -0.031 [-0.088, +0.030]   | -0.036 [-0.065, +0.010]   | +0.0010 [-0.0002, +0.0023]   |
-| 0.01 → 0.02     | -0.029 [-0.172, +0.100]   | -0.062 [-0.198, +0.035]   | +0.0000 [-0.0024, +0.0024]   |
-| 0.02 → 0.05     | +0.733 [+0.253, +1.339] R | +0.135 [-0.316, +0.762]   | +0.0136 [+0.0100, +0.0185] R |
-| 0.05 → 0.1      | +5.340 [+4.105, +6.951] R | +2.075 [+0.929, +3.961] R | +0.0637 [+0.0470, +0.0861] R |
+| 0.01 → 0.02     | -0.029 [-0.172, +0.100]   | -0.062 [-0.198, +0.035]   | +0.0000 [-0.0023, +0.0023]   |
+| 0.02 → 0.05     | +0.733 [+0.253, +1.339] R | +0.135 [-0.316, +0.762]   | +0.0136 [+0.0099, +0.0184] R |
+| 0.05 → 0.1      | +5.340 [+4.105, +6.951] R | +2.075 [+0.929, +3.961] R | +0.0637 [+0.0470, +0.0862] R |
 
 | r2d2 step       | ΔFID                         | ΔKID x1000                | ΔCMMD                        |
 | --------------- | ---------------------------- | ------------------------- | ---------------------------- |
 | 0 → 0.00392     | +0.000 [+0.000, +0.000]      | +0.000 [+0.000, +0.000]   | +0.0000 [+0.0000, +0.0000]   |
-| 0.00392 → 0.01  | +0.001 [-0.013, +0.012]      | -0.004 [-0.017, +0.008]   | +0.0006 [-0.0008, +0.0019]   |
-| 0.01 → 0.02     | -0.051 [-0.116, +0.009]      | -0.067 [-0.118, -0.024] R | +0.0071 [+0.0048, +0.0095] R |
-| 0.02 → 0.05     | +1.626 [+1.054, +2.246] R    | +0.561 [+0.135, +1.081] R | +0.0752 [+0.0627, +0.0877] R |
-| 0.05 → 0.1      | +12.001 [+9.925, +14.690] R  | +4.400 [+2.937, +6.391] R | +0.2511 [+0.2040, +0.2936] R |
+| 0.00392 → 0.01  | +0.001 [-0.013, +0.012]      | -0.004 [-0.017, +0.008]   | +0.0006 [-0.0007, +0.0018]   |
+| 0.01 → 0.02     | -0.051 [-0.116, +0.009]      | -0.067 [-0.118, -0.024] R | +0.0072 [+0.0048, +0.0096] R |
+| 0.02 → 0.05     | +1.626 [+1.054, +2.246] R    | +0.561 [+0.135, +1.081] R | +0.0752 [+0.0624, +0.0876] R |
+| 0.05 → 0.1      | +12.001 [+9.925, +14.690] R  | +4.400 [+2.937, +6.391] R | +0.2511 [+0.2039, +0.2937] R |
 
 The coarse end is close to unanimous. Every metric resolves 0.05 to 0.1 in both
 scenes, and 0.02 to 0.05 goes the same way everywhere except KID on gaudi. The
@@ -356,7 +356,7 @@ interval's near end still sits a third of the way to the estimate.
 
 The fine end resolves once, and the one time it does the metrics disagree about
 which way. On r2d2's 0.01 to 0.02 step KID reports -0.067 with an interval of
-[-0.118, -0.024] while CMMD reports +0.0071 with [+0.0048, +0.0095]: same
+[-0.118, -0.024] while CMMD reports +0.0072 with [+0.0048, +0.0096]: same
 images, same frames, both excluding zero, opposite signs. FID spans zero there,
 and on the other three fine steps all three metrics do. That is less damning
 than it first looks. KID measures a polynomial-kernel distance between Inception
@@ -441,9 +441,21 @@ and that quantity depends on the configuration being scored. On this ladder it
 does not move. The excess is 0.0160 on gaudi and 0.0156 on r2d2, the same to
 four decimals across all six rungs, and the configuration-dependent factor
 varies only in the fifth decimal. Recomputing every step with the unbiased
-estimator shifts none of them by more than 0.0002 and leaves every
-classification standing: r2d2's 0.01 to 0.02 step reads +0.0071 with
-[+0.0048, +0.0095] biased and +0.0071 with [+0.0046, +0.0095] unbiased.
+estimator shifts none of them by more than 0.0007 and leaves every
+classification standing: r2d2's 0.01 to 0.02 step reads +0.0072 with
+[+0.0048, +0.0096] biased and +0.0071 with [+0.0047, +0.0095] unbiased.
+
+Checking that turned up a fourth thing, which has nothing to do with either
+objection. CMMD is 1000 times the difference of three kernel means that all sit
+within 0.001 of 1.0, so in float32 the cancellation quantises the answer at
+1000 times 2^-23, or 0.00012. Two independent float32 runs of the same
+computation on the same images disagreed by up to 0.00048, and against float64
+each is out by up to 0.00022. Every CMMD number in this document is now
+accumulated in float64. The steps mostly survived the change, because the shared
+reference term cancels between the two configurations, but the fine ones are
+small enough that they need not have: gaudi's 0.00392 to 0.01 step is 0.0010,
+eight of those quantisation units. Four decimals on a float32 CMMD value are
+three decimals of number and one of rounding.
 
 #### How much of each is the sample count
 
@@ -454,7 +466,7 @@ Each estimator on the unpruned run, at four frame counts:
 | 28     | 75.46     | 1.528     | 0.4377     | 36     | 43.44    | -6.431   | 0.6206    |
 | 56     | 70.06     | 14.060    | 0.4842     | 73     | 38.58    | 1.164    | 0.6754    |
 | 84     | 67.34     | 14.559    | 0.4561     | 110    | 37.60    | 3.887    | 0.7154    |
-| 112    | 62.68     | 16.553    | 0.4554     | 147    | 35.83    | 4.214    | 0.6906    |
+| 112    | 62.68     | 16.553    | 0.4554     | 147    | 35.83    | 4.214    | 0.6907    |
 
 FID falls monotonically as frames are added in both scenes, which is the bias
 Chong and Forsyth describe. The drift is 12.8 points on gaudi against a ladder
@@ -468,7 +480,9 @@ KID is worse in a different way. A single draw at 36 frames puts the r2d2 run at
 produce and which supports no ordering whatsoever. Unbiased in expectation is
 not the same as usable from one draw at this size. CMMD wanders least in
 relative terms but still moves more between 28 and 56 frames than the entire
-0.02 to 0.05 step it is being asked to detect.
+0.02 to 0.05 step it is being asked to detect. Its rows below the full frame
+count are float32 and carry the 0.0002 noted above, which is two orders of
+magnitude under the drift being discussed.
 
 Three limits apply to all of the above. These are training views, which the
 model was fit to, so they understate every degradation. The reference set is our
@@ -511,9 +525,9 @@ differ:
 | step             | FID  | KID  | CMMD  |
 | ---------------- | ---- | ---- | ----- |
 | gaudi 0.02→0.05  | 2.65 | 0.49 | 6.27  |
-| gaudi 0.05→0.1   | 7.35 | 2.68 | 6.39  |
-| r2d2 0.02→0.05   | 5.35 | 2.33 | 11.77 |
-| r2d2 0.05→0.1    | 9.87 | 4.99 | 10.98 |
+| gaudi 0.05→0.1   | 7.35 | 2.68 | 6.38  |
+| r2d2 0.02→0.05   | 5.35 | 2.33 | 11.69 |
+| r2d2 0.05→0.1    | 9.87 | 4.99 | 10.96 |
 
 CMMD leads in three of the four and KID trails in all four, while FID takes the
 largest step on gaudi's coarsest. That is the comparison this conclusion

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -707,8 +707,11 @@ The fine steps are left out of that table on purpose. A higher ratio there would
 mean only that an estimator separates images that barely differ, and whether
 that is a virtue is the question no bound has settled.
 
-All three resolve the coarse rungs cleanly and agree on direction there, which
-is the regime where the choice of metric stops mattering.
+All three resolve the 0.05 to 0.1 step cleanly on both scenes and agree on
+direction across the coarse end, which is the regime where the choice of metric
+mostly stops mattering. The exception is KID on gaudi's 0.02 to 0.05 step, at
++0.047 with [-0.316, +0.762], which it fails to resolve at every block length
+tried.
 
 The larger conclusion is that this line of attack was aimed at a problem we do
 not have. Set-level metrics earn their keep when nothing corresponds between the

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -683,15 +683,18 @@ would settle it and costs one more render pass.
 | 0.05      | 0.00322 [0.00291, 0.00353]   | 43.20   | 0.00775 [0.00715, 0.00834]   | 42.14   |
 | 0.1       | 0.02032 [0.01871, 0.02191]   | 34.01   | 0.05406 [0.05050, 0.05780]   | 31.59   |
 
-These are lossless renders. The first attempt wrote JPEG at quality 95, which is
-what the throwaway render script used for this experiment did, and produced
-0.00085 and 0.00038 at the 0.01 rung, seventeen and nineteen times the truth.
-The repository's own orbit renderer defaults to JPEG at quality 100, so the
-figure below is an upper bound on what that one costs rather than a measurement
-of it. Encoding the same checkpoint twice at q95 and comparing the copies puts
-the encoder's error at 0.00795 LPIPS and 48.5 dB,
-which is nothing against a photograph, since renders sit around 22 dB from
-those, and overwhelming against another render at 61 to 68 dB. The artifacts
+These are lossless renders. The first attempt wrote JPEG at quality 95, the
+setting hardcoded in the throwaway script that rendered these frames, and
+produced 0.00085 and 0.00038 at the 0.01 rung, seventeen and nineteen times the
+truth. Re-encoding each lossless frame at q95 and scoring it against its own
+source puts the encoder's error at 0.00795 LPIPS and 48.5 dB on r2d2, 0.00597
+and 46.0 dB on gaudi. None of that comes from the rendering: the JPEG pass is
+byte for byte identical to those re-encodings on all 147 and 112 frames, so both
+passes drew the same pixels and the encoder is the only thing left between them.
+The repository's own orbit renderer defaults to quality 100, so 0.00795 bounds
+what that default costs rather than measuring it. Against a photograph the
+number is nothing, since renders sit around 22 dB from those, and against
+another render at 61 to 68 dB it is overwhelming. The artifacts
 mostly cancel between two nearly identical images and decorrelate as the images
 separate, so the contamination grows with the rung instead of sitting under
 everything as a constant floor: seventeen times at 0.01, six at 0.02, and still
@@ -802,10 +805,20 @@ The proposed experiment, in order:
    construction. That leaves DOVER, VSFA, FAST-VQA and Q-Align, which score each
    orbit on its own. DISTS and CW-SSIM can only be tested on held-out frames
    where a real photo exists, which is a different experiment against different
-   stimuli than the one a viewer judged. Count only pairs where the rater
-   was self-consistent and expressed a preference, and fix the acceptance
-   threshold in advance rather than after seeing the number. Adopting a metric
-   on the same comparisons that chose it measures nothing.
+   stimuli than the one a viewer judged. Score every pair the rater was
+   self-consistent on, including the ones they called identical both times.
+   Dropping those would validate a candidate on the pairs that were easy to
+   call and then wire it in for the close ones, which are the pairs it exists
+   to settle. A repeated "no difference" is a label like any other, so require
+   the metric to reproduce it: fit a deadband on the selection set wide enough
+   to contain the pairs called identical, then on the held-out set ask the
+   preference pairs to fall outside the band with the correct sign and the
+   indifference pairs to fall inside it. Report the two rates separately, and
+   fix both acceptance thresholds in advance rather than after seeing the
+   numbers. A candidate that gets the obvious pairs right and pushes the
+   indifferent ones outside its band has earned the obvious pairs only, and
+   should be used on that class alone. Adopting a metric on the same
+   comparisons that chose it measures nothing.
 
    Three outcomes are worth naming ahead of time. A metric clears the threshold
    and gets wired in after `export`, reported alongside `ns-eval`. Nothing

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -205,34 +205,41 @@ reaches zero at a width factor of 1.095, which sits between the two: [-0.145,
 The row should not be read as resolving anything, and the reason is dependence
 rather than sample size.
 
-That is a statement about this test, not about seeding, and the full walkthrough
-settles it without needing any of the estimates above. Rendering both
-configurations over all 112 frames and moving-block bootstrapping the mean gives
--0.0714 with [-0.098, -0.045] at block length 20 and [-0.102, -0.041] at 40,
-excluding zero at every block length tried. That interval needs no effective
-sample size and no autocorrelation sum: the resampling carries the dependence
-itself. The same treatment resolves both pruning comparisons at every block
-length as well, at +0.00054 [+0.00029, +0.00078] on gaudi and +0.00430
-[+0.00395, +0.00463] on r2d2. Seeding also moves LPIPS from 0.468 to 0.387 at
-10k steps and 0.341 to 0.282 at 30k. The effect is not in doubt. What the
-five-frame interval could carry is.
+A longer sequence is available, but it answers a different question. Rendering
+both configurations over all 112 training views and moving-block bootstrapping
+the mean gives -0.0714 with [-0.098, -0.045] at block length 20 and
+[-0.102, -0.041] at 40, excluding zero at every block length tried, and the same
+treatment resolves both pruning comparisons at every block length: +0.00054
+[+0.00029, +0.00078] on gaudi and +0.00430 [+0.00395, +0.00463] on r2d2. Those
+intervals need no effective sample size and no autocorrelation sum, because the
+resampling carries the dependence itself.
 
-Which points at the fix rather than the caveat. Every one of these comparisons
-has a full walkthrough available, so the eval-split table is a five-frame
-estimate of something 112 frames can measure directly. The block-bootstrapped
-full-sequence figures are the ones to trust, with the standing caveat that they
-score training views and so understate every degradation.
+They are not substitutes for the rows above. A training view is one the model
+was fit to, so an effect can be large and precisely estimated there while doing
+nothing for a pose the model never saw. Seeding is the case where that matters
+most, since better initial geometry could plausibly show up as a tighter fit to
+the views it was fitted on. The training-view interval is evidence about
+training views; treating a narrow one as settling the held-out question would be
+the estimand swapped under cover of a caveat.
 
-Three caveats. A dependence-robust interval computed from the eval frames alone,
+So the honest position on seeding is three-part. On training views the effect is
+large and resolved. On held-out views the five-frame test does not resolve it
+once dependence is accounted for. And the direction is the same at 10k and 30k
+steps, which is weak corroboration rather than strong, because both readings
+come from the same five frames: the 0.468 to 0.387 gap at 10k is the -0.081
+paired difference above written as levels, not a second measurement.
+
+Settling it needs more held-out frames, which needs a pinned eval set rather
+than a fraction split. That is the `eval_mode=filename` rerun already
+outstanding for the frame-count experiment, and it would fix both.
+
+Two caveats. A dependence-robust interval computed from the eval frames alone,
 block or HAC, is not available at five and seven observations: it would need the
-same long-lag autocorrelations, estimated from even less. That is why the
-correction to the table is a sensitivity analysis while the full-sequence
-figures above are a block bootstrap, and why the second is the one to lean on.
-The three comparisons measured here are the pruning pair on both scenes and the
-seeding pair on gaudi; the cap and `rasterize_mode` rows have no full-sequence
-figure and are assumed to sit inside the same range, which is untested. And all
-of this, autocorrelations and block intervals alike, comes from training views
-while the table scores held-out ones.
+same long-lag autocorrelations, estimated from even less. A sensitivity analysis
+is the ceiling, which is why the table cannot be repaired in place. And the
+three comparisons measured here are the pruning pair on both scenes and the
+seeding pair on gaudi; the cap and `rasterize_mode` rows have no autocorrelation
+of their own and are assumed to sit inside the same range, which is untested.
 
 Three things fall out.
 
@@ -652,7 +659,16 @@ metric.
 The section above ends by arguing that the pre-transform export is the better
 reference for anything applied after training. That is cheap to test, since the
 renders already exist. Each rung scored against the unpruned render at the same
-poses, per frame, LPIPS with a 95% interval on the mean:
+poses, per frame, LPIPS with a 95% interval on the mean.
+
+One thing the poses are not: an orbit. The argument for this reference includes
+that it works along the delivery camera path, and that remains an argument.
+These numbers come from the capture poses, because those are the renders already
+on disk. Whether a transform moves the image more or less at viewpoints away
+from the capture is a question this table does not answer, and pruning is a
+plausible place for it to differ, since a Gaussian that is edge-on from the
+capture is not edge-on from everywhere. Rendering the same rungs along an orbit
+would settle it and costs one more render pass.
 
 | threshold | gaudi LPIPS vs unpruned      | PSNR dB | r2d2 LPIPS vs unpruned       | PSNR dB |
 | --------- | ---------------------------- | ------- | ---------------------------- | ------- |

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -1030,10 +1030,21 @@ The proposed experiment, in order:
    separating them, which answers the question without a metric and means no
    metric can be validated on them either. A pair the rater flips on is a pair
    no metric can be scored against.
-3. **Select on one half, validate on the other.** Split the pairs into a
-   selection set and a held-out set before looking at any of them. Use the
-   selection set to pick a metric, then score the winner once on the held-out
-   set.
+3. **Select on one half, validate on the other.** Split into a selection set
+   and a held-out set before looking at any of them, and split by scene rather
+   than by pair. These candidates score content, not just degradation, so two
+   comparisons from the same reconstruction ladder of the same scene are not
+   independent: put one in each half and the selection set has already shown
+   the metric the scene it will be validated on, which inflates the held-out
+   rate by exactly the amount the split was meant to remove. Every pair from a
+   scene goes in the same half. Use the selection set to pick a metric, then
+   score the winner once on the held-out set.
+
+   That is expensive at this scale. Two scenes buys a split of one against one,
+   which validates on a single scene and says nothing about the next one, so a
+   validation worth running needs more scenes than this document has, not more
+   pairs per scene. Splitting by pair to get around that does not produce a
+   weaker validation, it produces a number that cannot be read at all.
 
    The candidates have to be no-reference, because an A/B of two orbits has no
    ground truth to reference. A novel orbit path has no captured photo to

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -487,6 +487,22 @@ frames are consecutive poses along a walkthrough, so neighbouring views share
 most of their content, and an i.i.d. resample treats them as independent
 observations and returns an interval narrower than the data supports.
 
+Enough of the procedure to rerun it. Each replicate draws ceil(n/L) block
+starts uniformly from 0 to n-1, takes L consecutive indices from each with
+wraparound past the end of the sequence, concatenates them and truncates back
+to n. One index set per replicate indexes the configuration under test, the one
+it is compared against, and the reference set alike, so the pairing survives the
+resample. The reported difference is the mean over replicates, the interval is
+their 2.5th and 97.5th percentiles, and R marks an interval that does not
+contain zero. The set-level tables use 400 replicates, the per-frame LPIPS ones
+2000, and the walkthrough comparison quoted earlier 20000. Each run seeds one
+generator at 0 and draws every step of the ladder from it in sequence, so
+rerunning a single step alone reproduces its estimate but not its exact
+interval, and the endpoints move in their last quoted digit between generators
+anyway. FID uses the low-rank Frechet identity described below, KID the
+unbiased estimator on the full set with no subset averaging, and CMMD the
+V-statistic accumulated in float64.
+
 How much it costs splits the metrics in two, and the split is the useful part of
 the check. Interval width at block length 20 over width at block length 1:
 
@@ -789,10 +805,19 @@ The proposed experiment, in order:
    apart" is both a likely outcome and a useful one, since it means ship the
    smaller file.
 
-   Show every pair at least twice, separated. The repeat is not padding: it
-   measures how often the rater agrees with themselves, which caps how much
-   agreement any metric could show. A pair the rater flips on is a pair no
-   metric can be scored against.
+   Show every pair three times, separated. The repeats are not padding: they
+   measure how often the rater agrees with themselves, which caps how much
+   agreement any metric could show. Two showings cannot establish that. A
+   rater guessing on a pair they see no difference in still repeats the same
+   answer about a third of the time when there are three responses to choose
+   from, and every one of those accidents would enter the next step as a
+   label. Requiring all three showings to agree drops that floor to one in
+   nine, and what it filters out is concentrated in the close pairs, which are
+   the ones the exercise is about. Report the raw agreement rate next to the
+   floor. A rate near it on the close pairs says the rater cannot separate
+   them at all, which answers the question without a metric and means no
+   metric can be validated on them either. A pair the rater flips on is a pair
+   no metric can be scored against.
 3. **Select on one half, validate on the other.** Split the pairs into a
    selection set and a held-out set before looking at any of them. Use the
    selection set to pick a metric, then score the winner once on the held-out

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -417,43 +417,63 @@ step being free.
 
 #### What to take from this
 
-Pruning at 0.05 against no pruning is the one comparison here with an
-independent answer, so it is the one to judge them on:
+Only one thing here is a fact about quality rather than about estimators: the
+0.00392 rung is the unpruned model, so its true difference is exactly zero.
+Every other rung's correct ordering is unknown. Nobody has collected opinion
+scores on this ladder, and the LPIPS numbers alongside it are a second fallible
+measurement rather than a label, from a metric this document spends its first
+section showing correlates about 0.5 with viewers. So what follows is a
+comparison of what these estimators can resolve, and not a ranking of which one
+is right.
 
-| measurement           | gaudi_fountain              | r2d2_new                    |
-| --------------------- | --------------------------- | --------------------------- |
-| paired LPIPS, held out | +0.0007 [+0.0004, +0.0010] | +0.0059 [+0.0040, +0.0080]  |
-| ΔFID                  | +0.761 [+0.241, +1.337]     | +1.591 [+1.171, +2.073]     |
-| ΔKID x1000            | -0.023 [-0.426, +0.415]     | +0.505 [+0.156, +0.929]     |
-| ΔCMMD                 | +0.0158 [+0.0108, +0.0213]  | +0.0833 [+0.0721, +0.0955]  |
+Pruning at 0.05 against no pruning is the step with an independent measurement
+to set against it:
 
-FID and CMMD both resolve it in both scenes and agree with the paired result.
-KID resolves only r2d2, the scene where the effect is eight times larger, and
-misses gaudi entirely.
+| measurement            | gaudi_fountain              | r2d2_new                    |
+| ---------------------- | --------------------------- | --------------------------- |
+| paired LPIPS, held out | +0.0007 [+0.0004, +0.0010]  | +0.0059 [+0.0040, +0.0080]  |
+| ΔFID                   | +0.761 [+0.241, +1.337]     | +1.591 [+1.171, +2.073]     |
+| ΔKID x1000             | -0.023 [-0.426, +0.415]     | +0.505 [+0.156, +0.929]     |
+| ΔCMMD                  | +0.0158 [+0.0108, +0.0213]  | +0.0833 [+0.0721, +0.0955]  |
 
-None of the three orders the whole ladder correctly, though. Each ranks at least
-one pruned configuration above the unpruned original. What separates them is
-whether they do it with confidence: CMMD's inversion sits inside an interval that
-spans zero, while FID and KID both produce a resolved step in the wrong
-direction. A metric that fails to resolve a step is far less dangerous than one
-that resolves it backwards.
+FID and CMMD resolve it in both scenes with the same sign as the paired LPIPS
+result. KID resolves only r2d2, where the LPIPS effect is eight times larger,
+and misses gaudi. Four metrics agreeing is worth more than any one of them
+alone, though they are all trained on ImageNet-scale photographs and could be
+sharing an error rather than converging on the truth.
 
-That puts CMMD first, FID second and useful as long as its level is never read
-as a number, and KID last. The ordering inverts what the sample-size argument
-predicted, because that argument was about bias while the thing breaking these
-estimators at roughly 100 frames is variance. KID has the cleanest bias property
-and the worst noise.
+At the fine end they stop agreeing. FID and KID each resolve a decrease
+somewhere in the first three rungs, CMMD resolves none of them, and the scenes
+disagree about which rung. Read as quality this would mean a little pruning
+helps, which is not absurd since the primitives being removed are the ones the
+model marked nearly invisible. Read as measurement it means the three estimators
+disagree at an effect size where at most one of them can be right, with no way
+to tell which from this data.
 
-The result to be most careful with is the easiest one. This test gave all three
-metrics the friendliest setup available: identical poses across configurations,
-a reference set photographed from those same poses, and training views the model
-had already fit. The case that motivated the question, comparing two exported
-assets along an orbit with no photograph anywhere near the camera path, removes
-every one of those advantages. A metric that inverts a ladder under these
-conditions has not earned that harder job. Use CMMD as a companion to the paired
-per-frame tests, keep the frame count fixed across everything being compared,
-and treat a single set-level number as a claim about a distribution rather than
-about what anyone sees.
+What survives without a quality label is the power ordering. At roughly 100
+frames CMMD resolves the most steps, FID resolves a similar number while its
+absolute level drifts 12.9 points with sample count, and KID resolves the
+fewest. That inverts what the sample-size argument predicted, because the
+argument was about bias while the binding constraint here is variance. KID has
+the cleanest bias property and the worst noise.
+
+The larger conclusion is that this line of attack was aimed at a problem we do
+not have. Set-level metrics earn their keep when nothing corresponds between the
+thing being scored and any reference. Scene reconstruction always has a capture,
+and for the questions this project actually asks, which are about transforms
+applied after training, there is a reference better suited than the photographs:
+the pre-transform export. Render it and the transformed asset at the same poses
+and the comparison is exact, paired per frame, free of transients, and available
+along the delivery camera path rather than only where someone stood with a
+camera.
+
+That measures the right quantity for a delivery decision, which is how far a
+transform moves the image away from the asset we would otherwise ship. It cannot
+say whether the move is an improvement, because the reference wins by
+construction, and it cannot say whether anyone would notice. Both still need the
+study below. What it does supply is the thing the photo-referenced ladder never
+had: at the rung that changes nothing the answer is zero by construction, so the
+measurement can be checked against a fact rather than against another metric.
 
 ## What to measure instead
 

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -287,10 +287,15 @@ frame indices once per replicate and recompute the *difference* under that
 shared resampling. The ladder is the opacity pruning threshold at 0, 0.00392,
 0.01, 0.02, 0.05 and 0.1.
 
-The first rung is a free calibration check. Splatfacto already culls at an
-alpha of 0.005 during training, so asking for 0.00392 afterwards removes
-nothing. Both scenes render byte-identical images to the unpruned run and the
-two configurations are the same model. FID and CMMD both return exactly zero
+The first rung is a free calibration check, and not by luck. 0.00392 is 1/255,
+which is the cutoff gsplat's rasterizer already applies: `alpha < 1.f / 255.f`
+then `continue`, in `rasterize_to_pixels_fwd.cu`. A Gaussian's alpha at a pixel
+is its opacity scaled by a factor no greater than one, so a Gaussian whose
+opacity sits below that line is skipped at every pixel and contributes to no
+image. Pruning at 1/255 cannot change a render, and both scenes duly produce
+byte-identical images to the unpruned run. The two configurations are the same
+model as far as anything downstream can tell. FID and CMMD both return exactly
+zero
 with a zero-width interval, which is what a correctly paired bootstrap has to
 return on identical inputs and what independent bootstrapping of the two
 estimates would not have returned. KID returned 0.30 instead, for reasons that
@@ -475,6 +480,47 @@ construction, and it cannot say whether anyone would notice. Both still need the
 study below. What it does supply is the thing the photo-referenced ladder never
 had: at the rung that changes nothing the answer is zero by construction, so the
 measurement can be checked against a fact rather than against another metric.
+
+## Scoring against the export instead of the photographs
+
+The section above ends by arguing that the pre-transform export is the better
+reference for anything applied after training. That is cheap to test, since the
+renders already exist. Each rung scored against the unpruned render at the same
+poses, per frame, LPIPS with a 95% interval on the mean:
+
+| threshold | gaudi LPIPS vs unpruned      | PSNR dB | r2d2 LPIPS vs unpruned       | PSNR dB |
+| --------- | ---------------------------- | ------- | ---------------------------- | ------- |
+| 0         | 0.00000 [0.00000, 0.00000]   | inf     | 0.00000 [0.00000, 0.00000]   | inf     |
+| 0.00392   | 0.00000 [0.00000, 0.00000]   | inf     | 0.00000 [0.00000, 0.00000]   | inf     |
+| 0.01      | 0.00085 [0.00083, 0.00087]   | 51.67   | 0.00038 [0.00037, 0.00039]   | 57.62   |
+| 0.02      | 0.00186 [0.00181, 0.00191]   | 48.08   | 0.00166 [0.00163, 0.00169]   | 51.25   |
+| 0.05      | 0.00552 [0.00540, 0.00565]   | 41.95   | 0.01019 [0.00998, 0.01039]   | 41.49   |
+| 0.1       | 0.02305 [0.02248, 0.02363]   | 33.78   | 0.05711 [0.05600, 0.05823]   | 31.50   |
+
+Every problem the distribution metrics had disappears. The ladder is monotone in
+both scenes. No neighbouring pair of intervals overlaps. The identity rung
+returns exactly zero with infinite PSNR, which is a fact rather than a
+calibration hope. Where FID, KID and CMMD each inverted somewhere and left the
+fine rungs unresolved, this separates all five rungs in both scenes, and the
+intervals are narrow enough that the separation is not close.
+
+The reason is not that LPIPS is a better metric than CMMD. It is that the
+comparison is paired at the level of individual frames against an exact
+reference, so nothing has to be estimated from a sample of 112 images. The
+question changed, and the easier question has a much better answer.
+
+What it buys is a real decision. Both scenes start from a 1M cap. Pruning at
+0.05 leaves 628k Gaussians on gaudi and 619k on r2d2, a cut of roughly 38% in
+both, and moves the delivered image by 0.0055 and 0.0102 LPIPS at 42 dB.
+Pruning at 0.1 leaves 446k and 324k, cuts of 55% and 68%, and moves it by 0.023
+and 0.057. The r2d2 cell at 0.1 is the only one that looks like a real cost. That is a defensible
+basis for setting the shipping threshold at 0.05, and it holds regardless of
+what the photographs contain or where the tourists were standing.
+
+Two things it still cannot do. The unpruned export wins by construction, so this
+can never report that pruning improved anything, only how far it moved. And a
+0.0055 LPIPS deviation is not a statement about what a viewer would notice,
+which remains the open question the study below is meant to close.
 
 ## What to measure instead
 

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -140,7 +140,11 @@ cancels in the differences. Re-running eval with per-frame output and testing
 the differences directly changes several verdicts.
 
 LPIPS, mean paired difference with a 95% interval, and how often the difference
-kept its sign across frames:
+kept its sign across frames. These intervals treat the frames as independent,
+which the section below shows is wrong for a walkthrough. It holds here because
+these are held-out eval frames, and nerfstudio's fraction split takes them as
+the complement of an evenly spaced training set: 23 frames apart on gaudi and 22
+on r2d2, further apart than the correlation length measured below.
 
 | Comparison | n | Mean diff | 95% CI | Paired SD | Marginal SD | Same sign |
 |---|---|---|---|---|---|---|
@@ -289,8 +293,9 @@ the capture photographs, on two scenes. CMMD uses CLIP ViT-L/14-336 features wit
 bicubic resize to 336 by 336; FID and KID use the standard 2048-d Inception
 pool3 features. Uncertainty comes from bootstrap replicates that resample the
 frame indices once per replicate and recompute the *difference* under that
-shared resampling. The ladder is the opacity pruning threshold at 0, 0.00392,
-0.01, 0.02, 0.05 and 0.1.
+shared resampling, in blocks of 20 consecutive frames for the reason set out
+under "What the intervals assume" below. The ladder is the opacity pruning
+threshold at 0, 0.00392, 0.01, 0.02, 0.05 and 0.1.
 
 The first rung is a free calibration check, and not by luck. 0.00392 is 1/255,
 which is the cutoff gsplat's rasterizer already applies: `alpha < 1.f / 255.f`
@@ -328,33 +333,32 @@ on the pair that renders byte-identical images.
 
 Steps, with an interval excluding zero marked R:
 
-| gaudi step      | ΔFID                    | ΔKID x1000              | ΔCMMD                     |
-| --------------- | ----------------------- | ----------------------- | ------------------------- |
-| 0 → 0.00392     | +0.000 [+0.000, +0.000] | +0.000 [+0.000, +0.000] | +0.0000 [0.0000, 0.0000]  |
-| 0.00392 → 0.01  | -0.036 [-0.082, +0.004] | -0.037 [-0.072, -0.001] R | +0.0009 [-0.0006, +0.0023] |
-| 0.01 → 0.02     | -0.011 [-0.131, +0.118] | -0.054 [-0.165, +0.053] | -0.0000 [-0.0018, +0.0019] |
-| 0.02 → 0.05     | +0.722 [+0.330, +1.013] R | +0.071 [-0.352, +0.532] | +0.0133 [+0.0095, +0.0178] R |
-| 0.05 → 0.1      | +5.514 [+4.150, +6.863] R | +1.842 [+0.906, +2.822] R | +0.0622 [+0.0528, +0.0720] R |
+| gaudi step      | ΔFID                      | ΔKID x1000                | ΔCMMD                        |
+| --------------- | ------------------------- | ------------------------- | ---------------------------- |
+| 0 → 0.00392     | +0.000 [+0.000, +0.000]   | +0.000 [+0.000, +0.000]   | +0.0000 [+0.0000, +0.0000]   |
+| 0.00392 → 0.01  | -0.031 [-0.088, +0.030]   | -0.036 [-0.065, +0.010]   | +0.0010 [-0.0002, +0.0023]   |
+| 0.01 → 0.02     | -0.029 [-0.172, +0.100]   | -0.062 [-0.198, +0.035]   | +0.0000 [-0.0024, +0.0024]   |
+| 0.02 → 0.05     | +0.733 [+0.253, +1.339] R | +0.135 [-0.316, +0.762]   | +0.0136 [+0.0100, +0.0185] R |
+| 0.05 → 0.1      | +5.340 [+4.105, +6.951] R | +2.075 [+0.929, +3.961] R | +0.0637 [+0.0470, +0.0861] R |
 
-| r2d2 step       | ΔFID                       | ΔKID x1000              | ΔCMMD                       |
-| --------------- | -------------------------- | ----------------------- | --------------------------- |
-| 0 → 0.00392     | +0.000 [+0.000, +0.000]    | +0.000 [+0.000, +0.000] | +0.0000 [0.0000, 0.0000]    |
-| 0.00392 → 0.01  | +0.000 [-0.013, +0.011]    | -0.005 [-0.013, +0.003] | +0.0006 [-0.0007, +0.0019]  |
-| 0.01 → 0.02     | -0.052 [-0.138, +0.010]    | -0.059 [-0.104, -0.019] R | +0.0069 [+0.0039, +0.0099] R |
-| 0.02 → 0.05     | +1.724 [+1.189, +2.245] R  | +0.522 [+0.170, +0.875] R | +0.0750 [+0.0664, +0.0849] R |
-| 0.05 → 0.1      | +11.871 [+10.422, +13.009] R | +3.949 [+2.907, +4.969] R | +0.2477 [+0.2168, +0.2786] R |
+| r2d2 step       | ΔFID                         | ΔKID x1000                | ΔCMMD                        |
+| --------------- | ---------------------------- | ------------------------- | ---------------------------- |
+| 0 → 0.00392     | +0.000 [+0.000, +0.000]      | +0.000 [+0.000, +0.000]   | +0.0000 [+0.0000, +0.0000]   |
+| 0.00392 → 0.01  | +0.001 [-0.013, +0.012]      | -0.004 [-0.017, +0.008]   | +0.0006 [-0.0008, +0.0019]   |
+| 0.01 → 0.02     | -0.051 [-0.116, +0.009]      | -0.067 [-0.118, -0.024] R | +0.0071 [+0.0048, +0.0095] R |
+| 0.02 → 0.05     | +1.626 [+1.054, +2.246] R    | +0.561 [+0.135, +1.081] R | +0.0752 [+0.0627, +0.0877] R |
+| 0.05 → 0.1      | +12.001 [+9.925, +14.690] R  | +4.400 [+2.937, +6.391] R | +0.2511 [+0.2040, +0.2936] R |
 
-The coarse end is unanimous. Every metric resolves 0.05 to 0.1 in both scenes
-and all but one resolves 0.02 to 0.05, with intervals nowhere near zero.
+The coarse end is close to unanimous. Every metric resolves 0.05 to 0.1 in both
+scenes, and 0.02 to 0.05 goes the same way everywhere except KID on gaudi. The
+weakest of the resolved cases is FID on gaudi's 0.02 to 0.05 step, where the
+interval's near end still sits a third of the way to the estimate.
 
-The fine end does not sort them out. FID resolves nothing there. CMMD resolves
-one step, r2d2 0.01 to 0.02, in the direction of more pruning meaning more
-deviation. KID resolves two, gaudi 0.00392 to 0.01 and r2d2 0.01 to 0.02, both
-negative, both saying pruning moved the render nearer the photographs.
-
-On r2d2's 0.01 to 0.02 step KID reports -0.059 with an interval of
-[-0.104, -0.019] while CMMD reports +0.0069 with [+0.0039, +0.0099]: same
-images, same frames, both excluding zero, opposite signs. That is less damning
+The fine end resolves once, and the one time it does the metrics disagree about
+which way. On r2d2's 0.01 to 0.02 step KID reports -0.067 with an interval of
+[-0.118, -0.024] while CMMD reports +0.0071 with [+0.0048, +0.0095]: same
+images, same frames, both excluding zero, opposite signs. FID spans zero there,
+and on the other three fine steps all three metrics do. That is less damning
 than it first looks. KID measures a polynomial-kernel distance between Inception
 features and CMMD an RBF distance between CLIP features, so a change in the
 images can genuinely shorten one and lengthen the other. Nothing is being
@@ -382,6 +386,64 @@ rung then returns exactly zero and the frame bootstrap is the only source of
 uncertainty left. Every KID number above is computed that way, and anyone
 comparing two configurations with KID should do the same, or at minimum share
 the subset draws between them.
+
+#### What the intervals assume
+
+Every interval above comes from a moving-block bootstrap with a block length of
+20, which resamples runs of consecutive frames instead of individual ones. The
+frames are consecutive poses along a walkthrough, so neighbouring views share
+most of their content, and an i.i.d. resample treats them as independent
+observations and returns an interval narrower than the data supports.
+
+How much it costs splits the metrics in two, and the split is the useful part of
+the check. Interval width at block length 20 over width at block length 1:
+
+| statistic                         | ratio        |
+| --------------------------------- | ------------ |
+| LPIPS, a mean of per-frame values | 3.0 to 3.8   |
+| FID, KID and CMMD, set-level      | 0.89 to 1.72 |
+
+The three set-level metrics are not separable from each other on this: FID runs
+0.89 to 1.61, KID 1.06 to 1.67, CMMD 0.91 to 1.72, all overlapping. What
+separates them from LPIPS is that a mean of per-frame values is exactly what
+correlated neighbours inflate, while a statistic computed from the whole
+resampled set absorbs the correlation. So block resampling matters a great deal
+for the export-referenced LPIPS ladder below and barely at all for this section.
+
+It does not overturn the LPIPS ladder. Every rung there stays separated from its
+neighbours by more than the width of either interval, at the widest block length
+tried. The LPIPS widths were still climbing at 20, by 16 to 22% over block length
+10, so they are a lower bound rather than a converged answer.
+
+FID needed a second fix for an unrelated reason. Its bootstrap had been running
+25 replicates, because the textbook Frechet term needs the square root of a
+2048 by 2048 matrix, and 25 draws cannot support a 2.5th percentile. It does not
+need that square root. With n frames and n well below 2048 both covariances have
+rank at most n-1, so the nonzero eigenvalues of the product live in an n by n
+matrix built from the centred feature blocks, and the trace term is the sum of
+their square roots. The identity agrees with torchmetrics to three parts in a
+million, with the residual a constant offset that cancels in a difference, and
+400 replicates now cost less than 25 did.
+
+Two classifications moved between them, both from resolved to unresolved. KID
+resolved gaudi's 0.00392 to 0.01 step under the i.i.d. bootstrap, at -0.037 with
+[-0.072, -0.001], and does not under blocks, at -0.036 with [-0.065, +0.010].
+FID resolved r2d2's 0.01 to 0.02 step on 25 replicates, at -0.052 with
+[-0.098, -0.001], and does not on 400, at -0.051 with [-0.116, +0.009]. Neither
+estimate shifted; both intervals grew past zero, which is what the fine end
+looks like once the interval stops being optimistic.
+
+CMMD needed a third. The implementation here is Google's, which uses the biased
+V-statistic rather than the unbiased U-statistic, and its bias is not a constant
+that a difference can be relied on to cancel: the excess over the U-statistic is
+one minus the mean off-diagonal kernel similarity, divided by n, once per set,
+and that quantity depends on the configuration being scored. On this ladder it
+does not move. The excess is 0.0160 on gaudi and 0.0156 on r2d2, the same to
+four decimals across all six rungs, and the configuration-dependent factor
+varies only in the fifth decimal. Recomputing every step with the unbiased
+estimator shifts none of them by more than 0.0002 and leaves every
+classification standing: r2d2's 0.01 to 0.02 step reads +0.0071 with
+[+0.0048, +0.0095] biased and +0.0071 with [+0.0046, +0.0095] unbiased.
 
 #### How much of each is the sample count
 
@@ -426,9 +488,9 @@ sensitivity looks like. Calling it an error would need an equivalence bound
 declared in advance and an interval that fits inside it, which is the same thing
 this document demands before anyone calls PSNR blind. No such bound exists here.
 
-So the fine end ranks nobody. FID resolves nothing, CMMD resolves one step, KID
-resolves two, and which behaviour is correct depends on a threshold nobody has
-set.
+So the fine end ranks nobody. FID resolves nothing there, KID and CMMD resolve
+the same single step and disagree about its sign, and which behaviour is correct
+depends on a threshold nobody has set.
 
 What does separate them needs no labels, because it is about the estimators
 rather than the images. Two things, and the first version of one of them was
@@ -446,21 +508,22 @@ resampling, so the ratio of a step to that deviation compares estimators in
 spite of their different units. On the four steps where the renders genuinely
 differ:
 
-| step             | FID   | KID  | CMMD  |
-| ---------------- | ----- | ---- | ----- |
-| gaudi 0.02→0.05  | 4.15  | 0.31 | 6.32  |
-| gaudi 0.05→0.1   | 7.97  | 3.77 | 12.70 |
-| r2d2 0.02→0.05   | 6.40  | 2.90 | 15.90 |
-| r2d2 0.05→0.1    | 17.98 | 7.50 | 15.72 |
+| step             | FID  | KID  | CMMD  |
+| ---------------- | ---- | ---- | ----- |
+| gaudi 0.02→0.05  | 2.65 | 0.49 | 6.27  |
+| gaudi 0.05→0.1   | 7.35 | 2.68 | 6.39  |
+| r2d2 0.02→0.05   | 5.35 | 2.33 | 11.77 |
+| r2d2 0.05→0.1    | 9.87 | 4.99 | 10.98 |
 
 CMMD leads in three of the four and KID trails in all four, while FID takes the
-largest step on r2d2. That is the comparison this conclusion needed. An earlier
-version rested it on KID returning -6.4 at 36 frames, which does not support
-anything: a negative value is exactly what an unbiased U-statistic is entitled
-to produce, it bars reading that point estimate as an absolute distance, and it
-leaves untouched the paired differences the tables above are built from. CMMD's
-estimator is the biased V-statistic and nonnegative by construction, so never
-going negative is a property of its formula rather than evidence of stability.
+largest step on gaudi's coarsest. That is the comparison this conclusion
+needed. An earlier version rested it on KID returning -6.4 at 36 frames, which
+does not support anything: a negative value is exactly what an unbiased
+U-statistic is entitled to produce, it bars reading that point estimate as an
+absolute distance, and it leaves untouched the paired differences the tables
+above are built from. CMMD's estimator is the biased V-statistic and nonnegative
+by construction, so never going negative is a property of its formula rather
+than evidence of stability.
 
 The fine steps are left out of that table on purpose. A higher ratio there would
 mean only that an estimator separates images that barely differ, and whether
@@ -498,10 +561,10 @@ poses, per frame, LPIPS with a 95% interval on the mean:
 | --------- | ---------------------------- | ------- | ---------------------------- | ------- |
 | 0         | 0.00000 [0.00000, 0.00000]   | inf     | 0.00000 [0.00000, 0.00000]   | inf     |
 | 0.00392   | 0.00000 [0.00000, 0.00000]   | inf     | 0.00000 [0.00000, 0.00000]   | inf     |
-| 0.01      | 0.00005 [0.00005, 0.00005]   | 61.02   | 0.00002 [0.00002, 0.00002]   | 68.01   |
-| 0.02      | 0.00030 [0.00029, 0.00031]   | 53.41   | 0.00031 [0.00030, 0.00032]   | 57.02   |
-| 0.05      | 0.00322 [0.00313, 0.00331]   | 43.20   | 0.00775 [0.00756, 0.00793]   | 42.14   |
-| 0.1       | 0.02032 [0.01979, 0.02084]   | 34.01   | 0.05406 [0.05291, 0.05520]   | 31.59   |
+| 0.01      | 0.00005 [0.00005, 0.00006]   | 61.02   | 0.00002 [0.00002, 0.00002]   | 68.01   |
+| 0.02      | 0.00030 [0.00027, 0.00033]   | 53.41   | 0.00031 [0.00028, 0.00034]   | 57.02   |
+| 0.05      | 0.00322 [0.00291, 0.00353]   | 43.20   | 0.00775 [0.00715, 0.00834]   | 42.14   |
+| 0.1       | 0.02032 [0.01871, 0.02191]   | 34.01   | 0.05406 [0.05050, 0.05780]   | 31.59   |
 
 These are lossless renders. The first attempt used the q95 JPEGs the render
 script writes by default and produced 0.00085 and 0.00038 at the 0.01 rung,
@@ -517,9 +580,12 @@ everything as a constant floor: seventeen times at 0.01, six at 0.02, and still
 Every problem the distribution metrics had disappears. The ladder is monotone in
 both scenes. No neighbouring pair of intervals overlaps. The identity rung
 returns exactly zero with infinite PSNR, which is a fact rather than a
-calibration hope. Where FID, KID and CMMD each inverted somewhere and left the
-fine rungs unresolved, this separates all five rungs in both scenes, and the
-intervals are narrow enough that the separation is not close.
+calibration hope. Where FID and KID both invert on both scenes and all three
+leave the fine rungs unresolved, this separates all five rungs in both scenes,
+and the intervals are narrow enough that the separation is not close. CMMD
+orders the ladder correctly, which is the one thing at the fine end it does that
+the other two do not, though every fine step of that ordering sits inside an
+interval spanning zero.
 
 The reason is not that LPIPS is a better metric than CMMD. It is that the
 comparison is paired at the level of individual frames against an exact

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -195,7 +195,12 @@ obvious partner made `rasterize_mode` look like a 0.083 LPIPS regression, which
 would have overturned a correct result. The run predates the seed point cloud
 landing in that scene directory, so the number was the seeding effect wearing a
 different label. Timestamps caught it. Against its actual control the difference
-is 0.0016 with the sign splitting 3/5, and `rasterize_mode` stays free.
+is 0.0016 with the sign splitting 3/5 and an interval running from -0.004 to
++0.007. That does not make `rasterize_mode` free, which is the same error this
+document objects to two paragraphs above: effects as large as either endpoint
+are still compatible with five frames. The honest statement is that the
+comparison is unresolved, and calling it free needs an equivalence bound set in
+advance with the whole interval inside it.
 
 ## Would FID or KID do better?
 

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -141,18 +141,42 @@ The proposed experiment, in order:
    shows the published 0.94 survives contact with our content and capture style;
    it does not yet show the metric is useful on close calls. Failing kills it
    outright, which is why this comes first and costs nothing.
-2. **The contested pairs.** Take the decisions we cannot currently settle, at
-   most a handful: cap_max 250k against 500k, cleanup at 0.05 against raw on a
-   scene where the filter takes 60%, 212 training views against 424. Render
-   orbits, present each pair side by side in randomised order without labels,
-   and record a forced choice. One rater is thin evidence, and it is still the
-   only direct evidence about the decisions we actually make; a published
-   correlation on someone else's stimuli is not a substitute.
-3. **Adopt or fall back.** If DOVER agrees with the forced choices, wire it in
-   after export and report it alongside `ns-eval`. If it disagrees, DISTS (0.73)
-   and CW-SSIM (0.74) are the next candidates and cost almost nothing to try. If
-   nothing agrees, the honest conclusion is that these calls are not
-   metric-decidable and we should pick on file size, which we can measure.
+2. **Paired comparisons on the contested decisions.** Three comparisons would
+   agree with any metric one time in eight, so the set has to be big enough for
+   agreement to mean something. The cleanup threshold supplies it for free: all
+   15 Gaudi scenes have an uncropped export and a filtered one, and the cut
+   ranges from 4.9% to 62%, which is a difficulty gradient rather than a single
+   point. Add the cap_max pairs from the existing sweep.
+
+   Present each pair as two orbits side by side, unlabelled, in randomised
+   left-right order, and offer three responses: left, right, or no difference.
+   Indifference has to be a legal answer. Forcing a choice between variants that
+   look identical manufactures a label out of nothing, and "we cannot tell them
+   apart" is both a likely outcome and a useful one, since it means ship the
+   smaller file.
+
+   Show every pair at least twice, separated. The repeat is not padding: it
+   measures how often the rater agrees with themselves, which caps how much
+   agreement any metric could show. A pair the rater flips on is a pair no
+   metric can be scored against.
+3. **Select on one half, validate on the other.** Split the pairs into a
+   selection set and a held-out set before looking at any of them. Use the
+   selection set to pick among DOVER, DISTS (0.73) and CW-SSIM (0.74), then
+   score the winner once on the held-out set. Count only pairs where the rater
+   was self-consistent and expressed a preference, and fix the acceptance
+   threshold in advance rather than after seeing the number. Adopting a metric
+   on the same comparisons that chose it measures nothing.
+
+   Three outcomes are worth naming ahead of time. A metric clears the threshold
+   and gets wired in after `export`, reported alongside `ns-eval`. Nothing
+   clears it, which means these calls are not metric-decidable for us and file
+   size decides. Or the rater is mostly indifferent, which settles the
+   underlying question without a metric: if 250k and 500k are indistinguishable
+   on an orbit, ship 250k.
+
+   One rater makes all of this suggestive rather than conclusive. It is still
+   direct evidence about the decisions we actually make, which a published
+   correlation on someone else's stimuli is not.
 4. **Build stimuli only if 1 to 3 leave a real gap.** MUGSQA covers the input
    axes and released its data, so what would remain is attribute-based pruning
    and container quantisation at fixed training. That is a much smaller build

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -528,19 +528,51 @@ The three set-level metrics are not separable from each other on this: FID runs
 0.89 to 1.61, KID 1.06 to 1.67, CMMD 0.91 to 1.72, all overlapping. What
 separates them from LPIPS is that a mean of per-frame values is exactly what
 correlated neighbours inflate, while a statistic computed from the whole
-resampled set absorbs the correlation. So block resampling matters a great deal
-for the export-referenced LPIPS ladder below and barely at all for this section.
+resampled set carries less of it. So block resampling costs the
+export-referenced LPIPS ladder below a great deal of width and this section
+almost none.
+
+Width is not the whole story, and stopping at 20 was a choice, so the set-level
+metrics got the same sweep out to 100. Their widths peak between 5 and 40
+depending on the step and shrink from 60 on, the same collapse the LPIPS ladder
+shows, so a long block is not a conservative block here either. Out to 40 no
+coarse verdict moves. The 0.02 to 0.05 and 0.05 to 0.1 steps stay resolved for
+every metric on both scenes except KID on gaudi's 0.02 to 0.05, which stays
+unresolved, and r2d2's 0.01 to 0.02 stays resolved for KID and CMMD in opposite
+directions at every length tried. Past 40 the collapse starts
+manufacturing resolutions instead: r2d2's 0.01 to 0.02 turns resolved for FID at
+60, gaudi's 0.01 to 0.02 for KID at 100.
+
+The rest of the fine end is worse than the tables make it look. Gaudi's 0.00392
+to 0.01 KID interval has an endpoint sitting on zero and changes verdict at
+almost every block length tried: resolved at 1, 10, 30 and everything from 60
+up, unresolved at 5, 20 and 40. That step is not measuring anything. The coarse
+conclusions do not depend on the block length, and the fine ones, apart from
+r2d2's 0.01 to 0.02, were never conclusions.
 
 It does not overturn the LPIPS ladder, and the widths do not run away either.
 At 20 they were still climbing, 16 to 22% over block length 10, which left the
 question of where they stop. Pushing the ladder out to block lengths of 30, 40,
 60, 80 and 100 answers it: every rung peaks at 40, 7 to 17% wider than at 20,
-and falls back after. That is forced by the resampling rather than by the data.
-A wrapped block of length L covers a fixed fraction of the sequence whatever its
-start, so as L approaches n every replicate converges on the full-sample mean
-and the interval has to collapse. The reported intervals stay at block length
-20, where the set-level metrics were also measured, and 40 is the honest worst
-case.
+and falls back after. The fall is forced by the resampling rather than by the
+data. A wrapped block of length L covers a fixed fraction of the sequence
+whatever its start, so as L approaches n every replicate converges on the
+full-sample mean and the interval has to collapse.
+
+That makes 40 the widest this resampling can go, which is not the same as a
+bound on the uncertainty, so two checks that do not depend on the sweep. The
+Politis-White automatic block length lands between 17 and 23 on all eight
+non-degenerate rungs, below the peak rather than beyond it. A Newey-West
+variance with a Bartlett kernel, which does not resample at all, gives widths
+within 14% of the length-40 bootstrap on every rung, and wider than it on one.
+Three different treatments of the dependence agree to about a tenth.
+
+What none of them do is bound dependence that 112 and 147 frames cannot show.
+On simulated AR(1) series of the same length and first-order correlation the
+Politis-White selector recovers 44 to 60% of the block length the closed form
+asks for, so it is known to run short in this regime, and doubling what it
+selects lands back at the swept peak. The reported intervals stay at block
+length 20, where the set-level metrics were also measured.
 
 FID needed a second fix for an unrelated reason. Its bootstrap had been running
 25 replicates, because the textbook Frechet term needs the square root of a
@@ -747,12 +779,14 @@ intervals overlaps. The identity rung returns exactly zero with infinite PSNR,
 which is a fact rather than a
 calibration hope. Where FID and KID both invert on both scenes and the three of
 them together resolve one fine step out of eight, this separates all five rungs
-in both scenes, and the separation holds at the block length where the intervals
-are widest. At 40 the tightest neighbouring gap is 2.6 times the wider of the
-two intervals on gaudi and 3.2 times on r2d2, and no pair comes closer than that
-at any block length from 1 to 100. CMMD does better than the other two at the
-fine end: it orders both ladders correctly, and it resolves r2d2's 0.01 to 0.02
-step, which KID also resolves in the opposite direction.
+in both scenes, and the separation survives every treatment of the dependence
+tried. The tightest neighbouring gap is 2.6 times the wider of the two intervals
+at the block length where the resampling is widest, 2.7 under a Newey-West
+variance at a bandwidth of 40, and no pair comes closer at any block length from
+1 to 100. Closing the tightest of those gaps takes a factor of 2.6 in width,
+against the tenth that separates the three treatments. CMMD does better than the
+other two at the fine end: it orders both ladders correctly, and it resolves
+r2d2's 0.01 to 0.02 step, which KID also resolves in the opposite direction.
 
 The reason is not that LPIPS is a better metric than CMMD. It is that the
 comparison is paired at the level of individual frames against an exact
@@ -926,3 +960,14 @@ Distribution metrics:
   CLIP features plus MMD, packaged as `clip-mmd`
 - ImageNet class dependence of FID:
   [arXiv:2203.06026](https://arxiv.org/abs/2203.06026), Kynkäänniemi et al.
+
+Resampling under dependence:
+
+- Politis and White, "Automatic Block-Length Selection for the Dependent
+  Bootstrap", Econometric Reviews 23(1), 53-70, 2004, with the correction in
+  Patton, Politis and White, Econometric Reviews 28(4), 372-375, 2009
+  ([PDF](https://public.econ.duke.edu/~ap172/Politis_White_2004.pdf),
+  [correction](https://public.econ.duke.edu/~ap172/Patton_Politis_White_2009.pdf))
+- Newey and West, "A Simple, Positive Semi-Definite, Heteroskedasticity and
+  Autocorrelation Consistent Covariance Matrix", Econometrica 55(3), 703-708,
+  1987

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -882,7 +882,13 @@ The proposed experiment, in order:
 
    Present each pair as two orbits side by side, unlabelled, in randomised
    left-right order, and offer three responses: left, right, or no difference.
-   Indifference has to be a legal answer. Forcing a choice between variants that
+   Record which configuration the answer names rather than which side. The order
+   is drawn again at every showing, so a rater who prefers the same asset three
+   times will have clicked different sides, and a rater who clicks the same side
+   every time will have named different assets. Scoring sides would reject the
+   first and accept the second, which is backwards. Scored by configuration a
+   fixed-side habit looks like guessing, which is what it is. Indifference has
+   to be a legal answer. Forcing a choice between variants that
    look identical manufactures a label out of nothing, and "we cannot tell them
    apart" is both a likely outcome and a useful one, since it means ship the
    smaller file.
@@ -915,11 +921,11 @@ The proposed experiment, in order:
    orbit on its own. DISTS and CW-SSIM can only be tested on held-out frames
    where a real photo exists, which is a different experiment against different
    stimuli than the one a viewer judged. Score a pair only when all three of its
-   showings gave the same response, which is the same bar step 2 sets, and score
-   every pair that clears it, including the ones called identical all three
-   times. Dropping those would validate a candidate on the pairs that were easy
-   to call and then wire it in for the close ones, which are the pairs it exists
-   to settle. A unanimous "no difference" is a label like any other, so require
+   showings named the same configuration, which is the same bar step 2 sets, and
+   score every pair that clears it, including the ones called identical all
+   three times. Dropping those would validate a candidate on the pairs that were
+   easy to call and then wire it in for the close ones, which are the pairs it
+   exists to settle. A unanimous "no difference" is a label like any other, so require
    the metric to reproduce it: fit a deadband on the selection set wide enough
    to contain the pairs called identical, then on the held-out set ask the
    preference pairs to fall outside the band with the correct sign and the
@@ -937,16 +943,20 @@ The proposed experiment, in order:
    without a metric: if 250k and 500k are indistinguishable on an orbit, ship
    250k.
 
-   Only the second and third outcomes are conclusions one rater can support.
-   Repeats measure whether a rater agrees with themselves, and a rater with a
-   consistent but idiosyncratic preference produces exactly the pattern a
-   metric can be fitted to, with nothing in the design able to tell that apart
-   from a preference other viewers would share. So a single rater can rule a
-   metric out, which is what the failing outcomes do, and cannot license wiring
-   one in after `export` for every asset we ship. That step needs a second
-   rater, recruited independently, scoring the same held-out pairs and agreeing
-   on them. Short of that the winner stays a diagnostic reported next to
-   `ns-eval` rather than a criterion anything is decided on.
+   With one rater all three are statements about that rater, and none is a
+   statement about viewers. Repeats measure whether a rater agrees with
+   themselves. A consistent but idiosyncratic preference produces exactly the
+   pattern a metric can be fitted to, an unusual detection threshold fails a
+   metric that would work for other people, and one insensitive rater's
+   indifference is not evidence that anybody else would miss the difference.
+   Nothing in the design separates any of those from the population case. So
+   the experiment as described settles what we default to and nothing wider,
+   and each outcome should be written down that way. Treating any of the three
+   as a claim about viewers needs a second rater, recruited independently and
+   scoring the same held-out pairs, and that goes double for wiring a metric in
+   after `export` for every asset we ship. Short of it the winner stays a
+   diagnostic reported next to `ns-eval` rather than a criterion anything is
+   decided on.
 4. **Build stimuli only if 1 to 3 leave a real gap.** MUGSQA covers the input
    axes and released its data, so what would remain is attribute-based pruning
    and container quantisation at fixed training. That is a much smaller build

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -107,11 +107,15 @@ a fixed set of Gaussians. GS-QA evaluates SOG, but as a reconstruction *method*
 with spherical harmonics removed during training, not as a container applied
 afterwards. Nothing published covers our version of the question.
 
-**The frame-count experiment.** Currently running at 106/212/424 training views
-with a pinned held-out set. MUGSQA's view-quantity axis is the closest prior
-work, and it also scores with 2D metrics, so it inherits the same ceiling. The
-experiment is still worth reading, but a small LPIPS delta between 212 and 424
-should not decide anything.
+**The frame-count experiment.** Ran at 106 and 212 training views against a
+pinned 11-frame held-out set, and came back a tie: PSNR 20.05 against 20.10,
+SSIM 0.519 against 0.532, LPIPS 0.3645 against 0.3677, all inside a per-image
+spread of 0.063 to 0.070. Doubling the training views moved nothing, and moved
+LPIPS the wrong way. This null is the one least troubled by the correlation
+ceiling, since the gap is a twentieth of the noise rather than a close call, but
+it is still a statement about what three 2D metrics can see. MUGSQA's
+view-quantity axis is the closest prior work and it scores with 2D metrics too,
+so it inherits the same limit.
 
 ## What to measure instead
 

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -433,20 +433,23 @@ Steps, with an interval excluding zero marked R:
 | 0.00392 → 0.01  | -0.028 [-0.088, +0.030]   | -0.038 [-0.065, +0.010]   | +0.0009 [-0.0002, +0.0023]   |
 | 0.01 → 0.02     | -0.024 [-0.172, +0.100]   | -0.055 [-0.198, +0.035]   | -0.0000 [-0.0023, +0.0023]   |
 | 0.02 → 0.05     | +0.702 [+0.253, +1.339] R | +0.047 [-0.316, +0.762]   | +0.0132 [+0.0099, +0.0184] R |
-| 0.05 → 0.1      | +4.772 [+4.105, +6.951] R | +1.694 [+0.929, +3.961] R | +0.0618 [+0.0470, +0.0862] R |
+| 0.05 → 0.1      | +4.772 [+4.105, +6.951] R | +1.694 [+0.929, +3.961]   | +0.0618 [+0.0470, +0.0862] R |
 
 | r2d2 step       | ΔFID                         | ΔKID x1000                | ΔCMMD                        |
 | --------------- | ---------------------------- | ------------------------- | ---------------------------- |
 | 0 → 0.00392     | +0.000 [+0.000, +0.000]      | +0.000 [+0.000, +0.000]   | +0.0000 [+0.0000, +0.0000]   |
 | 0.00392 → 0.01  | -0.001 [-0.013, +0.012]      | -0.005 [-0.017, +0.008]   | +0.0006 [-0.0007, +0.0018]   |
 | 0.01 → 0.02     | -0.049 [-0.116, +0.009]      | -0.059 [-0.118, -0.024] R | +0.0071 [+0.0048, +0.0096] R |
-| 0.02 → 0.05     | +1.511 [+1.054, +2.246] R    | +0.499 [+0.135, +1.081] R | +0.0746 [+0.0624, +0.0876] R |
+| 0.02 → 0.05     | +1.511 [+1.054, +2.246] R    | +0.499 [+0.135, +1.081]   | +0.0746 [+0.0624, +0.0876] R |
 | 0.05 → 0.1      | +10.577 [+9.925, +14.690] R  | +3.735 [+2.937, +6.391] R | +0.2442 [+0.2039, +0.2937] R |
 
-The coarse end is close to unanimous. Every metric resolves 0.05 to 0.1 in both
-scenes, and 0.02 to 0.05 goes the same way everywhere except KID on gaudi. The
-weakest of the resolved cases is FID on gaudi's 0.02 to 0.05 step, where the
-interval's near end still sits a third of the way to the estimate.
+The coarse end belongs to FID and CMMD. Both resolve 0.02 to 0.05 and 0.05 to
+0.1 on both scenes, and agree on direction throughout. KID resolves one of those
+four, r2d2's 0.05 to 0.1, and the intervals shown carry the R only where the
+percentile and basic constructions agree, which costs KID two of the three it
+had under the percentile alone. The weakest of the resolved cases is FID on
+gaudi's 0.02 to 0.05 step, where the interval's near end still sits a third of
+the way to the estimate.
 
 The fine end resolves once, and the one time it does the metrics disagree about
 which way. On r2d2's 0.01 to 0.02 step KID reports -0.059 with an interval of
@@ -513,8 +516,19 @@ Which point estimate gets reported is not a formality here. On r2d2's 0.05 to
 0.1 step the replicate mean sits at 12.00 FID against 10.58 observed and at 4.40
 KID against 3.74, so the percentile interval is dragged along with it and the
 observed value lands near its lower end rather than in the middle. CMMD moves by
-under three percent on the same step. Read the coarse FID and KID intervals as
-offset from their estimates rather than centred on them.
+under three percent on the same step.
+
+That shift belongs to the resampling rather than to the sampling uncertainty,
+and a percentile interval carries it into the verdict. The basic interval
+removes it by reflecting the replicates through the observed value, and the two
+constructions disagree on three steps, all of them KID: gaudi's 0.05 to 0.1 and
+r2d2's 0.02 to 0.05 lose their exclusion of zero, gaudi's 0.00392 to 0.01 gains
+one. FID and CMMD keep every classification under both. So R marks a step whose
+interval excludes zero under both constructions, and the three that disagree are
+left unresolved. Even that is generous in one place: r2d2's 0.01 to 0.02 clears
+under the basic interval by 0.00013 on a step of -0.059. The LPIPS ladder needs
+none of this, since the bootstrap expectation of a sample mean is the sample
+mean and there is no shift to remove.
 
 How much it costs splits the metrics in two, and the split is the useful part of
 the check. Interval width at block length 20 over width at block length 1:
@@ -536,19 +550,27 @@ Width is not the whole story, and stopping at 20 was a choice, so the set-level
 metrics got the same sweep out to 100. Their widths peak between 5 and 40
 depending on the step and shrink from 60 on, the same collapse the LPIPS ladder
 shows, so a long block is not a conservative block here either. Out to 40 no
-coarse verdict moves. The 0.02 to 0.05 and 0.05 to 0.1 steps stay resolved for
-every metric on both scenes except KID on gaudi's 0.02 to 0.05, which stays
-unresolved, and r2d2's 0.01 to 0.02 stays resolved for KID and CMMD in opposite
-directions at every length tried. Past 40 the collapse starts
-manufacturing resolutions instead: r2d2's 0.01 to 0.02 turns resolved for FID at
-60, gaudi's 0.01 to 0.02 for KID at 100.
+verdict moves with the block length. Under the percentile construction the 0.02
+to 0.05 and 0.05 to 0.1 steps stay resolved for every metric on both scenes
+except KID on gaudi's 0.02 to 0.05, which stays unresolved, and r2d2's 0.01 to
+0.02 stays resolved for KID and CMMD in opposite directions at every length
+tried. Crossing that sweep with the interval construction sorts the three
+metrics: CMMD holds every coarse verdict under both constructions at every block
+length, FID holds all of them except gaudi's 0.02 to 0.05 at block lengths 5 and
+10, and KID's coarse verdicts move with the block length, the construction, or
+both. Its gaudi 0.05 to 0.1 step, for one, excludes zero under the basic
+interval at block length 1 and from 60 up, and not between.
+
+Past 40 the collapse starts manufacturing resolutions instead: r2d2's 0.01 to
+0.02 turns resolved for FID at 60, gaudi's 0.01 to 0.02 for KID at 100.
 
 The rest of the fine end is worse than the tables make it look. Gaudi's 0.00392
 to 0.01 KID interval has an endpoint sitting on zero and changes verdict at
 almost every block length tried: resolved at 1, 10, 30 and everything from 60
 up, unresolved at 5, 20 and 40. That step is not measuring anything. The coarse
-conclusions do not depend on the block length, and the fine ones, apart from
-r2d2's 0.01 to 0.02, were never conclusions.
+conclusions for FID and CMMD survive both the block length and the construction,
+KID's do not, and the fine ones apart from r2d2's 0.01 to 0.02 were never
+conclusions.
 
 It does not overturn the LPIPS ladder, and the widths do not run away either.
 At 20 they were still climbing, 16 to 22% over block length 10, which left the
@@ -707,11 +729,12 @@ The fine steps are left out of that table on purpose. A higher ratio there would
 mean only that an estimator separates images that barely differ, and whether
 that is a virtue is the question no bound has settled.
 
-All three resolve the 0.05 to 0.1 step cleanly on both scenes and agree on
-direction across the coarse end, which is the regime where the choice of metric
-mostly stops mattering. The exception is KID on gaudi's 0.02 to 0.05 step, at
-+0.047 with [-0.316, +0.762], which it fails to resolve at every block length
-tried.
+FID and CMMD resolve both coarse steps on both scenes and agree on direction,
+which is the regime where the choice between those two stops mattering. KID does
+not join them. It fails gaudi's 0.02 to 0.05 outright, at +0.047 with
+[-0.316, +0.762] and unresolved at every block length tried, and loses gaudi's
+0.05 to 0.1 and r2d2's 0.02 to 0.05 once the interval stops carrying its own
+resampling bias.
 
 The larger conclusion is that this line of attack was aimed at a problem we do
 not have. Set-level metrics earn their keep when nothing corresponds between the
@@ -907,16 +930,23 @@ The proposed experiment, in order:
    should be used on that class alone. Adopting a metric on the same
    comparisons that chose it measures nothing.
 
-   Three outcomes are worth naming ahead of time. A metric clears the threshold
-   and gets wired in after `export`, reported alongside `ns-eval`. Nothing
-   clears it, which means these calls are not metric-decidable for us and file
-   size decides. Or the rater is mostly indifferent, which settles the
-   underlying question without a metric: if 250k and 500k are indistinguishable
-   on an orbit, ship 250k.
+   Three outcomes are worth naming ahead of time. A metric clears the threshold,
+   which makes it a candidate rather than a default. Nothing clears it, which
+   means these calls are not metric-decidable for us and file size decides. Or
+   the rater is mostly indifferent, which settles the underlying question
+   without a metric: if 250k and 500k are indistinguishable on an orbit, ship
+   250k.
 
-   One rater makes all of this suggestive rather than conclusive. It is still
-   direct evidence about the decisions we actually make, which a published
-   correlation on someone else's stimuli is not.
+   Only the second and third outcomes are conclusions one rater can support.
+   Repeats measure whether a rater agrees with themselves, and a rater with a
+   consistent but idiosyncratic preference produces exactly the pattern a
+   metric can be fitted to, with nothing in the design able to tell that apart
+   from a preference other viewers would share. So a single rater can rule a
+   metric out, which is what the failing outcomes do, and cannot license wiring
+   one in after `export` for every asset we ship. That step needs a second
+   rater, recruited independently, scoring the same held-out pairs and agreeing
+   on them. Short of that the winner stays a diagnostic reported next to
+   `ns-eval` rather than a criterion anything is decided on.
 4. **Build stimuli only if 1 to 3 leave a real gap.** MUGSQA covers the input
    axes and released its data, so what would remain is attribute-based pruning
    and container quantisation at fixed training. That is a much smaller build

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -224,8 +224,12 @@ the estimand swapped under cover of a caveat.
 
 So the honest position on seeding is three-part. On training views the effect is
 large and resolved. On held-out views the five-frame test does not resolve it
-once dependence is accounted for. And the direction is the same at 10k and 30k
-steps, which is weak corroboration rather than strong, because both readings
+under the sensitivity adjustment above, which is weaker than it sounds: that
+adjustment borrows its autocorrelation from the training-view sequence, and a
+set of poses the model was fitted to can differ from one it was not in
+covariance as easily as in mean. Nothing here estimates dependence from held-out
+frames, because five of them cannot. And the direction is the same at 10k and
+30k steps, which is weak corroboration rather than strong, because both readings
 come from the same five frames: the 0.468 to 0.387 gap at 10k is the -0.081
 paired difference above written as levels, not a second measurement.
 
@@ -690,9 +694,13 @@ separate, so the contamination grows with the rung instead of sitting under
 everything as a constant floor: seventeen times at 0.01, six at 0.02, and still
 1.7 at 0.05. Write PNG for any render-against-render comparison.
 
-Every problem the distribution metrics had disappears. The ladder is monotone in
-both scenes. No neighbouring pair of intervals overlaps. The identity rung
-returns exactly zero with infinite PSNR, which is a fact rather than a
+Every problem the distribution metrics had at the fine end disappears. The pose
+question is not one of them: those were scored on the same capture poses, and
+the difference is that they could not have been scored anywhere else, since the
+photographs only exist where someone stood. This comparison could be, and has
+not been. The ladder is monotone in both scenes. No neighbouring pair of
+intervals overlaps. The identity rung returns exactly zero with infinite PSNR,
+which is a fact rather than a
 calibration hope. Where FID and KID both invert on both scenes and the three of
 them together resolve one fine step out of eight, this separates all five rungs
 in both scenes, and the intervals are narrow enough that the separation is not
@@ -702,12 +710,18 @@ resolves in the opposite direction.
 
 The reason is not that LPIPS is a better metric than CMMD. It is that the
 comparison is paired at the level of individual frames against an exact
-reference, so nothing has to be estimated from a sample of 112 images. The
-question changed, and the easier question has a much better answer.
+reference, so two of the three things the set metrics estimate stop being
+estimated: the reference is the pre-transform render rather than a photograph,
+and the quantity is a per-frame difference rather than a distance between two
+fitted distributions. The third remains. The mean over poses is still a sample
+average over 112 correlated cameras, which is why it carries a bootstrap
+interval and why the choice of poses matters. The question changed, and the
+easier question has a much better answer, but it is not an exact one.
 
 What it buys is a real decision. Both scenes start from a 1M cap. Pruning at
 0.05 leaves 628k Gaussians on gaudi and 619k on r2d2, a cut of roughly 38% in
-both, and moves the delivered image by 0.0032 and 0.0078 LPIPS at 42 to 43 dB.
+both, and moves the image at the capture poses by 0.0032 and 0.0078 LPIPS at 42
+to 43 dB.
 Pruning at 0.1 leaves 446k and 324k, cuts of 55% and 68%, and moves it by 0.020
 and 0.054 at around 32 dB.
 

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -691,16 +691,20 @@ rank at most n-1, so the nonzero eigenvalues of the product live in an n by n
 matrix built from the centred feature blocks, and the trace term is the sum of
 their square roots. The identity agrees with torchmetrics to three parts in a
 million, with the residual a constant offset that cancels in a difference, and
-400 replicates now cost less than 25 did.
+it is about 1500 times faster per evaluation at 112 frames, so the 4000
+replicates the tables use cost a tenth of what 25 of the old ones did.
 
-Two classifications moved between them, both from resolved to unresolved. KID
-resolved gaudi's 0.00392 to 0.01 step under the i.i.d. bootstrap, where -0.038
-carried [-0.072, -0.001], and does not under blocks, where the same -0.038
-carries [-0.065, +0.010]. FID resolved r2d2's 0.01 to 0.02 step on 25
-replicates, where -0.049 carried [-0.098, -0.001], and does not on 400, where it
-carries [-0.116, +0.009]. The estimate cannot move, since it is the difference
-on the observed sample either way; both intervals grew past zero, which is what
-the fine end looks like once the interval stops being optimistic.
+Two classifications moved when those two changes landed, both from resolved to
+unresolved. FID resolved r2d2's 0.01 to 0.02 step on 25 replicates, where -0.049
+carried [-0.098, -0.001], and does not once the replicate count can support the
+tail: the same -0.049 carries [-0.119, +0.012] at the 4000 the tables report.
+KID resolved gaudi's 0.00392 to 0.01 step under the i.i.d. bootstrap and not
+under blocks, which is the opposite of what the paired-U estimator does with
+that step now; it is the case discussed under the block sweep above, and it
+carries no R either way. The estimate cannot move in either case, since it is
+the difference on the observed sample whatever the resampling does; the
+intervals grew past zero, which is what the fine end looks like once the
+interval stops being optimistic.
 
 CMMD needed a third. The implementation here is Google's, which uses the biased
 V-statistic rather than the unbiased U-statistic, and its bias is not a constant

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -154,17 +154,33 @@ kept its sign across frames:
 
 Three things fall out.
 
-**Opacity pruning is not free.** At 0.05 it costs 0.0007 LPIPS on gaudi and
-0.0059 on r2d2, and the sign holds on every frame of both scenes, with PSNR and
-SSIM agreeing. The marginal spread is 70 times the gaudi effect, which is why it
-read as noise. The trade is still worth taking for a median 28% size cut. The
-verdict of "free" was not.
+**Opacity pruning produces a repeatable objective regression.** At 0.05 it moves
+LPIPS by 0.0007 on gaudi and 0.0059 on r2d2, and the sign holds on every frame
+of both scenes, with PSNR and SSIM agreeing. The marginal spread is 70 times the
+gaudi effect, which is why it read as noise.
 
-**PSNR and SSIM really are blind to the Gaussian budget.** This one survives
-pairing and gets stronger for it. Across both cap steps the PSNR interval
-contains zero and the sign splits 3/5, while LPIPS separates every step cleanly.
-Pairing removed the excuse that the effect was hiding in the noise: it is not
-there.
+Calling that a perceptual cost would repeat the mistake this document is about.
+Movement in these metrics is sensitivity, and their agreement with viewers runs
+around 0.5, so 0.0007 LPIPS is a measured change in a number and not a known
+change in what anyone sees. Whether it is worth a median 28% size cut is exactly
+the trade the paired-comparison experiment exists to settle, and until that runs
+the honest statement is that the filter has a small consistent effect on three
+objective metrics. The earlier verdict of "free" was wrong for a different and
+simpler reason: it was never measured.
+
+**PSNR and SSIM respond far more weakly to the Gaussian budget than LPIPS.**
+Across both cap steps the PSNR interval contains zero and the sign splits 3/5,
+while LPIPS separates every step cleanly. Measured against each metric's own
+paired noise, the 100k to 250k step moves LPIPS by 6.1 standard deviations, SSIM
+by 0.77, and PSNR by 0.001. PSNR and SSIM do not belong in the same sentence
+here: PSNR's response is about four orders of magnitude weaker than LPIPS's,
+while SSIM's is merely too weak to resolve on five frames.
+
+That is the defensible claim, and "blind" is not. Five frames failing to reject
+zero is not evidence of no effect, and the PSNR interval spans plus or minus
+0.24 dB, which is wide enough to contain changes that would matter. Saying the
+effect is absent needs an equivalence bound declared in advance and an interval
+that fits inside it, neither of which exists here.
 
 **Effects come in two kinds, and the marginal spread cannot tell them apart.**
 Seeding moves LPIPS by 0.081 with a paired SD of 0.060, almost as large as the
@@ -230,9 +246,14 @@ current best version of it.
 
 Three cautions before treating any of them as an answer.
 
-They give one number per set, so they cannot be paired the way everything in the
-table above was. Uncertainty has to come from bootstrapping over frames, and the
-paired comparison that made the pruning effect visible has no analogue.
+They give one number per set, so uncertainty has to come from bootstrapping over
+frames rather than from a per-frame difference. The pairing does survive that,
+as long as it is built in: two configurations rendered at the same orbit poses
+and scored against the same capture set share both sets of indices, so a
+replicate should resample the frame indices and the reference indices once and
+recompute the *difference* under that shared resampling. Bootstrapping the two
+estimates independently throws away the covariance, which is the thing that made
+a 0.0007 effect visible in the first place.
 
 They are insensitive to exactly the errors a reconstruction makes. A render that
 is plausible but geometrically wrong scores well, because the feature

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -45,10 +45,16 @@ stimuli the way the averaged panel ranked them about (1+t)/2 of the time. On
 LPIPS drops to 64%. A coin flip is 50%.
 
 Read that as agreement with a mean opinion score, not with any individual
-viewer. Per-viewer agreement is lower, since the panel average smooths out
-disagreement between people, and none of these papers reports the subject-level
-numbers that would pin it down. Either way, a metric that reproduces the panel's
-ordering two times in three is not settling a close call.
+viewer, and treat the per-viewer number as unknown. It is usually lower, because
+averaging cancels the part of each viewer's response that is noise and leaves a
+cleaner target to correlate against, but that reasoning assumes viewers share
+one ordering and differ by noise around it. Where they hold different orderings
+the mean represents no one, and a metric that happens to track one subgroup can
+agree with that subgroup more often than with the average. None of these papers
+reports the subject-level numbers that would say which case this is. The
+conclusion does not turn on it: a metric that reproduces the panel's ordering
+two times in three is not settling a close call, and neither direction of the
+per-viewer correction makes it one.
 
 ### What each study degraded
 

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -279,8 +279,8 @@ same bias already documented for the held-out frames.
 ### What happened when I ran them
 
 I ran all three rather than leaving the question open. Every training view of
-each configuration, rendered at full resolution and compared against the capture
-photographs, on two scenes. CMMD uses CLIP ViT-L/14-336 features with a single
+each configuration, rendered at full resolution without loss and scored against
+the capture photographs, on two scenes. CMMD uses CLIP ViT-L/14-336 features with a single
 bicubic resize to 336 by 336; FID and KID use the standard 2048-d Inception
 pool3 features. Uncertainty comes from bootstrap replicates that resample the
 frame indices once per replicate and recompute the *difference* under that
@@ -294,174 +294,140 @@ is its opacity scaled by a factor no greater than one, so a Gaussian whose
 opacity sits below that line is skipped at every pixel and contributes to no
 image. Pruning at 1/255 cannot change a render, and both scenes duly produce
 byte-identical images to the unpruned run. The two configurations are the same
-model as far as anything downstream can tell. FID and CMMD both return exactly
-zero
-with a zero-width interval, which is what a correctly paired bootstrap has to
-return on identical inputs and what independent bootstrapping of the two
-estimates would not have returned. KID returned 0.30 instead, for reasons that
-turned out to be worth a section of their own.
+model as far as anything downstream can tell. All three return exactly zero on it with a
+zero-width interval, which is what a correctly paired bootstrap has to return on
+identical inputs and what independent bootstrapping of the two estimates would
+not have returned. KID only does so after the fix described below; on its
+standard protocol it returned 0.30.
 
-#### FID
+#### What each one did
 
-| threshold | gaudi FID | r2d2 FID |
-| --------- | --------- | -------- |
-| 0         | 62.19     | 35.59    |
-| 0.00392   | 62.19     | 35.59    |
-| 0.01      | 62.11     | 35.59    |
-| 0.02      | 62.09     | 35.52    |
-| 0.05      | 62.91     | 37.04    |
-| 0.1       | 67.56     | 47.62    |
+The rungs to watch are the fine ones, because the section below measures what
+actually separates them: 61 dB on gaudi and 68 dB on r2d2 between the unpruned
+render and the 0.01 rung, 53 and 57 dB at 0.02. Those are not small differences
+so much as absent ones. A metric that resolves a step there with confidence is
+reporting something that is not in the images.
 
-| step           | gaudi ΔFID [95% CI]        | r2d2 ΔFID [95% CI]           |
-| -------------- | -------------------------- | ---------------------------- |
-| 0 → 0.00392    | +0.000 [+0.000, +0.000]    | +0.000 [+0.000, +0.000]      |
-| 0.00392 → 0.01 | -0.069 [-0.143, -0.014]    | -0.001 [-0.031, +0.024]      |
-| 0.01 → 0.02    | -0.053 [-0.183, +0.102]    | -0.054 [-0.140, +0.033]      |
-| 0.02 → 0.05    | +0.880 [+0.289, +1.491]    | +1.637 [+1.260, +2.137]      |
-| 0.05 → 0.1     | +5.144 [+4.101, +6.286]    | +11.856 [+10.456, +13.232]   |
+| rung    | gaudi FID | gaudi KID x1000 | gaudi CMMD | r2d2 FID | r2d2 KID x1000 | r2d2 CMMD |
+| ------- | --------- | --------------- | ---------- | -------- | -------------- | --------- |
+| 0       | 62.68     | 16.553          | 0.4553     | 35.83    | 4.214          | 0.6908    |
+| 0.00392 | 62.68     | 16.553          | 0.4553     | 35.83    | 4.214          | 0.6908    |
+| 0.01    | 62.65     | 16.515          | 0.4563     | 35.82    | 4.209          | 0.6911    |
+| 0.02    | 62.63     | 16.460          | 0.4562     | 35.78    | 4.150          | 0.6984    |
+| 0.05    | 63.33     | 16.507          | 0.4696     | 37.29    | 4.649          | 0.7730    |
+| 0.1     | 68.10     | 18.200          | 0.5312     | 47.86    | 8.384          | 1.0171    |
 
-FID inverts at the fine end in both scenes and, on gaudi, does so with an
-interval that excludes zero: pruning at 0.01 is confidently ranked better than
-not pruning at all. r2d2 shows the same dip without resolving it. Confidently
-ranking a degradation as an improvement in one scene and not the other is the
-failure mode to worry about, because nothing in the output marks which scene you
-are in.
+All three pass the null rung exactly, returning zero with a zero-width interval
+on the pair that renders byte-identical images.
 
-The sample-size bias is the part to take seriously. The unpruned gaudi run reads
-75.12, 69.38, 66.64 and 62.19 at 28, 56, 84 and 112 frames, and the unpruned
-r2d2 run reads 43.20, 38.42, 37.31 and 35.59 at 36, 73, 110 and 147. Both fall
-monotonically as frames are added, exactly the behaviour Chong and Forsyth
-describe. On gaudi that drift spans 12.9 FID points against a ladder whose whole
-range is 5.4. The number is therefore uninterpretable on its own, and comparing
-two configurations evaluated at different frame counts would be meaningless. The
-steps above survive only because the shared bootstrap cancels the part of the
+Steps, with an interval excluding zero marked R:
+
+| gaudi step      | ΔFID                    | ΔKID x1000              | ΔCMMD                     |
+| --------------- | ----------------------- | ----------------------- | ------------------------- |
+| 0 → 0.00392     | +0.000 [+0.000, +0.000] | +0.000 [+0.000, +0.000] | +0.0000 [0.0000, 0.0000]  |
+| 0.00392 → 0.01  | -0.036 [-0.082, +0.004] | -0.037 [-0.072, -0.001] R | +0.0009 [-0.0006, +0.0023] |
+| 0.01 → 0.02     | -0.011 [-0.131, +0.118] | -0.054 [-0.165, +0.053] | -0.0000 [-0.0018, +0.0019] |
+| 0.02 → 0.05     | +0.722 [+0.330, +1.013] R | +0.071 [-0.352, +0.532] | +0.0133 [+0.0095, +0.0178] R |
+| 0.05 → 0.1      | +5.514 [+4.150, +6.863] R | +1.842 [+0.906, +2.822] R | +0.0622 [+0.0528, +0.0720] R |
+
+| r2d2 step       | ΔFID                       | ΔKID x1000              | ΔCMMD                       |
+| --------------- | -------------------------- | ----------------------- | --------------------------- |
+| 0 → 0.00392     | +0.000 [+0.000, +0.000]    | +0.000 [+0.000, +0.000] | +0.0000 [0.0000, 0.0000]    |
+| 0.00392 → 0.01  | +0.000 [-0.013, +0.011]    | -0.005 [-0.013, +0.003] | +0.0006 [-0.0007, +0.0019]  |
+| 0.01 → 0.02     | -0.052 [-0.138, +0.010]    | -0.059 [-0.104, -0.019] R | +0.0069 [+0.0039, +0.0099] R |
+| 0.02 → 0.05     | +1.724 [+1.189, +2.245] R  | +0.522 [+0.170, +0.875] R | +0.0750 [+0.0664, +0.0849] R |
+| 0.05 → 0.1      | +11.871 [+10.422, +13.009] R | +3.949 [+2.907, +4.969] R | +0.2477 [+0.2168, +0.2786] R |
+
+The coarse end is unanimous. Every metric resolves 0.05 to 0.1 in both scenes
+and all but one resolves 0.02 to 0.05, with intervals nowhere near zero.
+
+The fine end separates them. FID resolves nothing there, which is the right
+answer. CMMD resolves one step, r2d2 0.01 to 0.02, in the direction of more
+pruning meaning more deviation. KID resolves two, gaudi 0.00392 to 0.01 and
+r2d2 0.01 to 0.02, both negative, both saying pruning moved the render closer to
+the photographs at a rung where the render barely moved at all.
+
+One pair settles it without any appeal to what a viewer would say. On r2d2's
+0.01 to 0.02 step KID reports -0.059 with an interval of [-0.104, -0.019] and
+CMMD reports +0.0069 with [+0.0039, +0.0099]. Same images, same frames, both
+intervals excluding zero, opposite signs. At most one of them is right, and
+nothing about the ladder or about human preference is needed to say so.
+
+An earlier version of this section had FID committing the same error, resolving
+gaudi's 0.00392 to 0.01 step as an improvement. That was the JPEG encoder rather
+than the metric, and it disappeared when the renders were written losslessly.
+The correction is recorded because it is the same failure the document is about,
+made while writing it: a resolved interval on an artifact.
+
+#### A flaw in the standard KID protocol
+
+KID needed fixing before any of the above could be read. The usual protocol
+averages the unbiased MMD over random subsets of the two feature sets, and
+drawing those subsets independently for the two configurations under comparison
+injects noise that the pairing cannot cancel, because the two runs never see the
+same subsets. On the null rung, where the render sets are byte-identical, the
+first pass scored 15.76 against 16.07, a difference of 0.30 where the truth is
+exactly zero and against a ladder spanning 1.7 end to end. The estimator is
+unbiased on the whole set, so the subsetting can be dropped outright. The null
+rung then returns exactly zero and the frame bootstrap is the only source of
+uncertainty left. Every KID number above is computed that way, and anyone
+comparing two configurations with KID should do the same, or at minimum share
+the subset draws between them.
+
+#### How much of each is the sample count
+
+Each estimator on the unpruned run, at four frame counts:
+
+| frames | gaudi FID | gaudi KID | gaudi CMMD | frames | r2d2 FID | r2d2 KID | r2d2 CMMD |
+| ------ | --------- | --------- | ---------- | ------ | -------- | -------- | --------- |
+| 28     | 75.46     | 1.528     | 0.4377     | 36     | 43.44    | -6.431   | 0.6206    |
+| 56     | 70.06     | 14.060    | 0.4842     | 73     | 38.58    | 1.164    | 0.6754    |
+| 84     | 67.34     | 14.559    | 0.4561     | 110    | 37.60    | 3.887    | 0.7154    |
+| 112    | 62.68     | 16.553    | 0.4554     | 147    | 35.83    | 4.214    | 0.6906    |
+
+FID falls monotonically as frames are added in both scenes, which is the bias
+Chong and Forsyth describe. The drift is 12.8 points on gaudi against a ladder
+whose whole range is 5.4, so the number cannot be read on its own and two
+configurations evaluated at different frame counts cannot be compared at all.
+The steps above survive because the shared bootstrap cancels the part of that
 bias the two runs have in common.
 
-#### KID, and a flaw in the standard protocol
-
-KID needed fixing before it could be read. The usual protocol averages the
-unbiased MMD over random subsets of the two feature sets, and my first run drew
-those subsets independently for each configuration. On the byte-identical rung
-that produced 15.76 against 16.07, a difference of 0.30 where the truth is
-exactly zero, against a full ladder spanning only 1.7. The sampling noise was
-larger than every step at the fine end and the pairing could not cancel it,
-because the two runs never saw the same subsets. The estimator is unbiased on
-the whole set, so I dropped the subsetting and computed it there. The identical
-rung then returned exactly zero and the frame bootstrap became the only source
-of uncertainty. Anyone comparing two configurations with KID should do the same,
-or at minimum share the subset draws between them.
-
-| threshold | gaudi KID x1000 | r2d2 KID x1000 |
-| --------- | --------------- | -------------- |
-| 0         | 16.103          | 4.034          |
-| 0.00392   | 16.103          | 4.034          |
-| 0.01      | 16.017          | 4.030          |
-| 0.02      | 15.965          | 3.955          |
-| 0.05      | 16.063          | 4.485          |
-| 0.1       | 17.682          | 8.232          |
-
-KID orders the ladder worse than CMMD does. Both scenes rank 0.05 below the
-unpruned run, and each contains one resolved decrease at the fine end, gaudi at
-the 0.01 rung and r2d2 at the 0.02 rung, so KID reports pruning as a small
-improvement with confidence in both. Only the step from 0.05 to 0.1 separates
-cleanly in both scenes.
-
-Sample count hits KID hardest. A single draw at 36 frames puts every r2d2 rung
-at roughly -6.6, a negative squared distance, which the unbiased estimator is
-free to produce but which no longer supports an ordering. The same rungs read
-+4.0 at 147 frames. The estimator is unbiased in expectation, and that is not
-the same as usable from one draw at this size.
-
-#### CMMD
-
-| threshold | gaudi_fountain (n=112) | r2d2_new (n=147) |
-| --------- | ---------------------- | ---------------- |
-| 0         | 0.3661                 | 0.6176           |
-| 0.00392   | 0.3661                 | 0.6176           |
-| 0.01      | 0.3670                 | 0.6196           |
-| 0.02      | 0.3664                 | 0.6258           |
-| 0.05      | 0.3819                 | 0.7008           |
-| 0.1       | 0.4327                 | 0.9505           |
-
-Past that the two scenes disagree. r2d2 orders the ladder correctly. gaudi does
-not, scoring 0.02 below 0.01, so the ordering inverts at the fine end.
-
-| step             | gaudi ΔCMMD [95% CI]        | r2d2 ΔCMMD [95% CI]         |
-| ---------------- | --------------------------- | --------------------------- |
-| 0 → 0.00392      | +0.0000 [+0.0000, +0.0000]  | +0.0000 [+0.0000, +0.0000]  |
-| 0.00392 → 0.01   | +0.0011 [-0.0010, +0.0030]  | +0.0020 [-0.0001, +0.0042]  |
-| 0.01 → 0.02      | -0.0008 [-0.0037, +0.0017]  | +0.0062 [+0.0008, +0.0114]  |
-| 0.02 → 0.05      | +0.0155 [+0.0108, +0.0210]  | +0.0741 [+0.0638, +0.0854]  |
-| 0.05 → 0.1       | +0.0511 [+0.0409, +0.0615]  | +0.2532 [+0.2229, +0.2870]  |
-
-The coarse steps resolve in both scenes with intervals well clear of zero. The
-finest step resolves in neither.
-
-The comparison worth putting weight on is the one the paired test already
-answered. Pruning at 0.05 against no pruning gives +0.0158 on gaudi with an
-interval of [0.0108, 0.0213], and +0.0833 on r2d2 with [0.0721, 0.0955]. Both
-exclude zero, and both agree in sign with the paired LPIPS results of +0.0007
-and +0.0059. On this comparison a set-level distribution metric and a per-frame
-perceptual one reach the same verdict, which is worth something given that they
-are not even looking at the same frames.
-
-Sample size stays a problem. The unpruned gaudi run scores 0.3597 at 28 frames,
-0.3883 at 56, 0.3669 at 84 and 0.3662 at 112. The level wanders by more than the
-0.0158 effect it is being asked to measure, and at 28 frames the fine rungs sit
-below the unpruned run. This is the sample-size instability Jayasumana et al.
-document for FID, reappearing in their own replacement at the sample counts a
-single capture provides. The coarse ordering survives it. The fine ordering does
-not.
+KID is worse in a different way. A single draw at 36 frames puts the r2d2 run at
+-6.4, a negative squared distance, which an unbiased estimator is entitled to
+produce and which supports no ordering whatsoever. Unbiased in expectation is
+not the same as usable from one draw at this size. CMMD wanders least in
+relative terms but still moves more between 28 and 56 frames than the entire
+0.02 to 0.05 step it is being asked to detect.
 
 Three limits apply to all of the above. These are training views, which the
-model was fit to, so they understate every degradation. The paired LPIPS numbers
-they are being compared against came from the five and seven held-out frames
-instead, so agreement between the two is agreement about the configurations and
-not about the same measurement. And an interval spanning zero means the test
+model was fit to, so they understate every degradation. The reference set is our
+own capture frames, tourists included, so a model that correctly drops a
+transient is penalised for it. And an interval spanning zero means the test
 could not resolve that step at this sample size, which is not the same as the
 step being free.
 
 #### What to take from this
 
-Only one thing here is a fact about quality rather than about estimators: the
-0.00392 rung is the unpruned model, so its true difference is exactly zero.
-Every other rung's correct ordering is unknown. Nobody has collected opinion
-scores on this ladder, and the LPIPS numbers alongside it are a second fallible
-measurement rather than a label, from a metric this document spends its first
-section showing correlates about 0.5 with viewers. So what follows is a
-comparison of what these estimators can resolve, and not a ranking of which one
-is right.
+No opinion scores exist for this ladder, so none of this ranks the three metrics
+by correctness. What it does have is one fact that needs no labels. The renders
+at the fine rungs differ by 53 to 68 dB, measured directly in the section below,
+and two images that close are not different in any way a metric should be able
+to speak confidently about. That is enough to read a resolved interval there as
+a fault rather than as sensitivity.
 
-Pruning at 0.05 against no pruning is the step with an independent measurement
-to set against it:
+By that standard FID comes out clean at the fine end, CMMD reports one resolved
+step, and KID reports two. KID's are the awkward ones: both say pruning brought
+the render closer to the photographs, and its disagreement with CMMD on r2d2's
+0.01 to 0.02 step is a flat contradiction between two intervals that both
+exclude zero. The estimator with the cleanest theoretical property at small n
+produced the least trustworthy output, and the reason is that the argument for
+it was about bias while the constraint that actually bites at 112 frames is
+variance.
 
-| measurement            | gaudi_fountain              | r2d2_new                    |
-| ---------------------- | --------------------------- | --------------------------- |
-| paired LPIPS, held out | +0.0007 [+0.0004, +0.0010]  | +0.0059 [+0.0040, +0.0080]  |
-| ΔFID                   | +0.761 [+0.241, +1.337]     | +1.591 [+1.171, +2.073]     |
-| ΔKID x1000             | -0.023 [-0.426, +0.415]     | +0.505 [+0.156, +0.929]     |
-| ΔCMMD                  | +0.0158 [+0.0108, +0.0213]  | +0.0833 [+0.0721, +0.0955]  |
-
-FID and CMMD resolve it in both scenes with the same sign as the paired LPIPS
-result. KID resolves only r2d2, where the LPIPS effect is eight times larger,
-and misses gaudi. Four metrics agreeing is worth more than any one of them
-alone, though they are all trained on ImageNet-scale photographs and could be
-sharing an error rather than converging on the truth.
-
-At the fine end they stop agreeing. FID and KID each resolve a decrease
-somewhere in the first three rungs, CMMD resolves none of them, and the scenes
-disagree about which rung. Read as quality this would mean a little pruning
-helps, which is not absurd since the primitives being removed are the ones the
-model marked nearly invisible. Read as measurement it means the three estimators
-disagree at an effect size where at most one of them can be right, with no way
-to tell which from this data.
-
-What survives without a quality label is the power ordering. At roughly 100
-frames CMMD resolves the most steps, FID resolves a similar number while its
-absolute level drifts 12.9 points with sample count, and KID resolves the
-fewest. That inverts what the sample-size argument predicted, because the
-argument was about bias while the binding constraint here is variance. KID has
-the cleanest bias property and the worst noise.
+Set against that, all three resolve the coarse rungs cleanly and agree on
+direction there. If a set-level number is wanted, CMMD is the one to use and the
+frame count has to be held fixed across everything being compared, since FID's
+level alone drifts 12.8 points between 28 and 112 frames.
 
 The larger conclusion is that this line of attack was aimed at a problem we do
 not have. Set-level metrics earn their keep when nothing corresponds between the
@@ -478,8 +444,8 @@ transform moves the image away from the asset we would otherwise ship. It cannot
 say whether the move is an improvement, because the reference wins by
 construction, and it cannot say whether anyone would notice. Both still need the
 study below. What it does supply is the thing the photo-referenced ladder never
-had: at the rung that changes nothing the answer is zero by construction, so the
-measurement can be checked against a fact rather than against another metric.
+had: an answer that is checkable against a fact rather than against another
+metric.
 
 ## Scoring against the export instead of the photographs
 
@@ -536,7 +502,7 @@ what the photographs contain or where the tourists were standing.
 
 Two things it still cannot do. The unpruned export wins by construction, so this
 can never report that pruning improved anything, only how far it moved. And a
-0.0055 LPIPS deviation is not a statement about what a viewer would notice,
+0.0032 LPIPS deviation is not a statement about what a viewer would notice,
 which remains the open question the study below is meant to close.
 
 ## What to measure instead
@@ -632,13 +598,6 @@ Treat 0.5 as a reason to distrust close calls, not as an error rate for ours.
 
 DBCNN at 0.88 and GSOQA at 0.77 are trained or cross-validated on the same
 dataset they score. They are not drop-in metrics.
-
-Every render behind the distribution-metric numbers is a JPEG at quality 95.
-That is well below the effects at the coarse end of the ladder and it is shared
-by every configuration, but at the fine end, where the differences approach the
-encoder's own error, some of what those metrics failed to resolve may be the
-encoding rather than the estimator. Any rerun aimed at the fine rungs should
-write PNG.
 
 3DGS-QA reports FAST-VQA at 0.29 while 3DGS-VBench reports 0.93. The two
 datasets contain different distortions and different content, and neither paper

--- a/scripts/clean_splat.py
+++ b/scripts/clean_splat.py
@@ -10,14 +10,20 @@ Only the opacity stage is on by default, because it is the only one whose cost h
 been measured. Matched pairs tested frame by frame put the LPIPS change at 0.05 at
 +0.0007 on a cluttered outdoor capture and +0.0059 on a sharp object capture, with
 the sign holding on every frame of both; at 0.10 it is +0.0042 and +0.0373. Those
-are changes in an objective metric, not measured perceptual costs. 0.05 is the
-portable default because the sharp capture loses roughly nine times what the
-outdoor one does at either threshold, so 0.10 is where that gap starts to matter,
-and not because either setting is free. An earlier version of this note called
-0.10 free on the outdoor capture, which compared it to the per-image spread
-instead of to its own paired noise; see docs/evaluation.md. The scale, anisotropy
-and outlier stages are implemented but off until they have been measured the same
-way; see hummat/mini-mesh#30.
+are changes in an objective metric, not measured perceptual costs.
+
+0.05 is provisional, not validated. What the measurements establish is the shape
+of the tradeoff rather than the right point on it: moving from 0.05 to 0.10
+removes a further 18 to 30 percentage points of Gaussians and multiplies the
+deviation from the unpruned render by six to seven (0.0032 and 0.0078 LPIPS at
+0.05, 0.020 and 0.054 at 0.10). Choosing a point needs a viewer study or an
+objective acceptance bound set in advance, and there is neither. An earlier
+version of this note called 0.10 free on the outdoor capture, which compared it
+to the per-image spread instead of to its own paired noise; see
+docs/evaluation.md and hummat/mini-mesh#34.
+
+The scale, anisotropy and outlier stages are implemented but off until they have
+been measured the same way; see hummat/mini-mesh#30.
 
 The output is always binary_little_endian, whatever the input was.
 """

--- a/scripts/clean_splat.py
+++ b/scripts/clean_splat.py
@@ -6,13 +6,18 @@ to a rendered view: near-transparent blobs, a few enormous ones covering half th
 scene, and needle-shaped slivers. They cost file size and viewer performance
 without earning it back in quality.
 
-Only the opacity stage is on by default, because it is the only one whose quality
-cost has been measured (by filtering a checkpoint and re-running ns-eval): at 0.05
-it removes roughly 38% of Gaussians for an LPIPS change well inside the per-image
-spread on both a cluttered outdoor capture and a sharp object capture. 0.10 is
-free on the former and costs a full spread on the latter, so it is not a safe
-default. The scale, anisotropy and outlier stages are implemented but off until
-they have been measured the same way; see hummat/mini-mesh#30.
+Only the opacity stage is on by default, because it is the only one whose cost has
+been measured. Matched pairs tested frame by frame put the LPIPS change at 0.05 at
++0.0007 on a cluttered outdoor capture and +0.0059 on a sharp object capture, with
+the sign holding on every frame of both; at 0.10 it is +0.0042 and +0.0373. Those
+are changes in an objective metric, not measured perceptual costs. 0.05 is the
+portable default because the sharp capture loses roughly nine times what the
+outdoor one does at either threshold, so 0.10 is where that gap starts to matter,
+and not because either setting is free. An earlier version of this note called
+0.10 free on the outdoor capture, which compared it to the per-image spread
+instead of to its own paired noise; see docs/evaluation.md. The scale, anisotropy
+and outlier stages are implemented but off until they have been measured the same
+way; see hummat/mini-mesh#30.
 
 The output is always binary_little_endian, whatever the input was.
 """

--- a/scripts/export.sh
+++ b/scripts/export.sh
@@ -148,12 +148,44 @@ should_run_export_dir() {
   return 0
 }
 
+# Orbit frames are the one export whose contents depend on a format flag, so a
+# directory left over from an earlier format is not the output that was asked
+# for. Rendering into it anyway would mix .jpg and .png in one sequence, and a
+# consumer globbing for either would then read a set that is part one and part
+# the other.
+should_run_orbit_export() {
+  local output_path="$1"
+  local want="$2"
+  local stale
+
+  if [ -d "$output_path" ] && [ "${overwrite:-false}" = true ]; then
+    # Re-rendering into frames of the other format would leave one sequence
+    # holding both, so the old ones go before the new ones land.
+    find "$output_path" -mindepth 1 -maxdepth 1 \
+      \( -iname '*.jpg' -o -iname '*.jpeg' -o -iname '*.png' \) -delete
+  fi
+
+  should_run_export_dir "$output_path" || {
+    if [ "$want" = png ]; then
+      stale="$(find "$output_path" -mindepth 1 -maxdepth 1 \
+        \( -iname '*.jpg' -o -iname '*.jpeg' \) -print -quit)"
+    else
+      stale="$(find "$output_path" -mindepth 1 -maxdepth 1 -iname '*.png' -print -quit)"
+    fi
+    if [ -n "$stale" ]; then
+      echo "[WARN]: those frames are not $want; --overwrite re-renders them in the requested format"
+    fi
+    return 1
+  }
+  return 0
+}
+
 run_nerfstudio_orbit_frames_export() {
   local exp_path="$1"
   local output_path
   output_path="$(orbit_frames_output_path "$exp_path")"
 
-  if should_run_export_dir "$output_path"; then
+  if should_run_orbit_export "$output_path" "$orbit_image_format"; then
     if [ -n "$data_path" ]; then
       run_cmd python "$script_dir/render_nerfstudio_orbit.py" \
         --load-config "$exp_path/config.yml" \
@@ -188,7 +220,7 @@ run_sdf_orbit_frames_export() {
     echo "[WARN]: sdf-render has no image format option; SDF orbit frames stay JPEG"
   fi
 
-  if should_run_export_dir "$output_path"; then
+  if should_run_orbit_export "$output_path" jpeg; then
     run_cmd sdf-render \
       --load-config "$exp_path/config.yml" \
       --traj spiral \

--- a/scripts/export.sh
+++ b/scripts/export.sh
@@ -159,6 +159,7 @@ run_nerfstudio_orbit_frames_export() {
         --load-config "$exp_path/config.yml" \
         --output-path "$output_path" \
         --data "$data_path" \
+        --image-format "$orbit_image_format" \
         --seconds 30 \
         --frame-rate 1
     else
@@ -166,6 +167,7 @@ run_nerfstudio_orbit_frames_export() {
         --load-config "$exp_path/config.yml" \
         --output-path "$output_path" \
         --output-format images \
+        --image-format "$orbit_image_format" \
         --seconds 30 \
         --frame-rate 1
     fi
@@ -180,6 +182,10 @@ run_sdf_orbit_frames_export() {
 
   if [ -n "$data_path" ]; then
     sdf_render_args+=("--data" "$data_path")
+  fi
+
+  if [ "$orbit_image_format" != jpeg ]; then
+    echo "[WARN]: sdf-render has no image format option; SDF orbit frames stay JPEG"
   fi
 
   if should_run_export_dir "$output_path"; then
@@ -245,6 +251,7 @@ function show_help {
   echo "                              --appearance-mode <mean|index>            Appearance bake mode for splatfacto-w-light (default: mean)"
   echo "                              --appearance-idx <int>                    Camera index for appearance embedding"
   echo "                              --method <string[,string...]>             Export method(s): poisson, tsdf, pointcloud, orbit-frames (default: poisson for NeRF)"
+  echo "                              --orbit-image-format <jpeg|png>           Orbit frame format for NeRF/splat exports (default: jpeg)"
   echo "                              --obb-center <float float float>          Center of crop box, turns cropping on (default: 0 0 0)"
   echo "                              --obb-rotation <float float float>        Rotation of crop box, turns cropping on (default: 0 0 0)"
   echo "                              --obb-scale <float float float>           Size of crop box, turns cropping on (default: 1 1 1)"
@@ -291,6 +298,9 @@ clean_splat=true
 nerf_methods=()
 method_requested=false
 orbit_frames_requested=false
+# Delivery frames are what orbit-frames is for, so JPEG stays the default. Frames
+# meant to be scored against other renders need png; see docs/evaluation.md.
+orbit_image_format=jpeg
 # These are the values used when the user asks for a box, not a default box.
 # nerfstudio crops only when all three flags are given (exporter.py:619), so
 # passing them unconditionally would clip every export to a half-unit cube in a
@@ -389,6 +399,16 @@ while [ $i -lt ${#export_args[@]} ]; do
       require_args "${export_args[$i]}" 1 "$remaining"
       val="${export_args[$((i+1))]}"
       add_export_methods "$val"
+      i=$((i+2))
+      ;;
+    --orbit-image-format)
+      require_args "${export_args[$i]}" 1 "$remaining"
+      val="${export_args[$((i+1))]}"
+      case "$val" in
+        jpeg|png) ;;
+        *) echo "[ERROR]: --orbit-image-format must be one of: jpeg, png"; exit 1 ;;
+      esac
+      orbit_image_format="$val"
       i=$((i+2))
       ;;
     --obb-center|--obb-rotation|--obb-scale)

--- a/scripts/render_nerfstudio_orbit.py
+++ b/scripts/render_nerfstudio_orbit.py
@@ -1,5 +1,15 @@
 #!/usr/bin/env python3
-"""Render Nerfstudio spiral orbit frames with a portable data-path override."""
+"""Render Nerfstudio spiral orbit frames with a portable data-path override.
+
+Pass --image-format png when the frames will be compared against other renders
+rather than looked at. JPEG artifacts largely cancel between two near-identical
+images and decorrelate as the images separate, so the contamination grows with
+the effect being measured instead of sitting under it as a constant floor. At
+q95 the encoder's own error measured 0.00795 LPIPS and 48.5 dB, against renders
+that differ from each other by 61 to 68 dB, which inflated a pruning ladder by
+up to 19x. The default here is q100 rather than q95, so it is better than that
+and still lossy and still unmeasured. See docs/evaluation.md.
+"""
 
 from __future__ import annotations
 

--- a/scripts/render_nerfstudio_orbit.py
+++ b/scripts/render_nerfstudio_orbit.py
@@ -2,7 +2,8 @@
 """Render Nerfstudio spiral orbit frames with a portable data-path override.
 
 Pass --image-format png when the frames will be compared against other renders
-rather than looked at. JPEG artifacts largely cancel between two near-identical
+rather than looked at, or --orbit-image-format png if you are going through
+scripts/export.sh, which passes it here. JPEG artifacts largely cancel between two near-identical
 images and decorrelate as the images separate, so the contamination grows with
 the effect being measured instead of sitting under it as a constant floor. At
 q95 the encoder's own error measured 0.00795 LPIPS and 48.5 dB, against renders

--- a/scripts/render_nerfstudio_orbit.py
+++ b/scripts/render_nerfstudio_orbit.py
@@ -7,8 +7,9 @@ images and decorrelate as the images separate, so the contamination grows with
 the effect being measured instead of sitting under it as a constant floor. At
 q95 the encoder's own error measured 0.00795 LPIPS and 48.5 dB, against renders
 that differ from each other by 61 to 68 dB, which inflated a pruning ladder by
-up to 19x. The default here is q100 rather than q95, so it is better than that
-and still lossy and still unmeasured. See docs/evaluation.md.
+up to 19x. The q100 default here is not reliably safer: PSNR improves with the
+quality setting but LPIPS does not, and on one of the two scenes measured q100
+scores worse than q95. See docs/evaluation.md.
 """
 
 from __future__ import annotations

--- a/tests/test_export_script.py
+++ b/tests/test_export_script.py
@@ -553,6 +553,68 @@ class TestExportScriptNerfWorkflow:
         assert "--frame-rate 1" in log
         assert "ns-export poisson" not in log
 
+    def test_orbit_frames_default_to_jpeg(self, tmp_path: Path) -> None:
+        """Delivery frames stay JPEG unless the caller asks otherwise."""
+        repo_root = Path(__file__).resolve().parents[1]
+        exp_path = tmp_path / "train" / "scene" / "nerfacto"
+        exp_path.mkdir(parents=True, exist_ok=True)
+        (exp_path / "config.yml").write_text("dummy: true\n", encoding="utf-8")
+
+        log_path = tmp_path / "stub.log"
+        bin_dir = tmp_path / "bin"
+        _make_stub_binaries(bin_dir, log_path)
+
+        env_overrides = {
+            "PATH": f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}",
+            "MINI_MESH_STUB_LOG": str(log_path),
+        }
+
+        result = _run_export_script(
+            repo_root, exp_path, ["--method", "orbit-frames"], env_overrides
+        )
+        assert result.returncode == 0, result.stderr
+        assert "--image-format jpeg" in log_path.read_text(encoding="utf-8")
+
+    def test_orbit_frames_accept_png_for_measurement(self, tmp_path: Path) -> None:
+        """Frames scored against other renders need the lossless format to reach ns-render."""
+        repo_root = Path(__file__).resolve().parents[1]
+        exp_path = tmp_path / "train" / "scene" / "nerfacto"
+        exp_path.mkdir(parents=True, exist_ok=True)
+        (exp_path / "config.yml").write_text("dummy: true\n", encoding="utf-8")
+
+        log_path = tmp_path / "stub.log"
+        bin_dir = tmp_path / "bin"
+        _make_stub_binaries(bin_dir, log_path)
+
+        env_overrides = {
+            "PATH": f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}",
+            "MINI_MESH_STUB_LOG": str(log_path),
+        }
+
+        result = _run_export_script(
+            repo_root,
+            exp_path,
+            ["--method", "orbit-frames", "--orbit-image-format", "png"],
+            env_overrides,
+        )
+        assert result.returncode == 0, result.stderr
+        assert "--image-format png" in log_path.read_text(encoding="utf-8")
+
+    def test_orbit_image_format_rejects_unknown_value(self, tmp_path: Path) -> None:
+        """An unsupported format fails loudly rather than reaching the renderer."""
+        repo_root = Path(__file__).resolve().parents[1]
+        exp_path = tmp_path / "train" / "scene" / "nerfacto"
+        exp_path.mkdir(parents=True, exist_ok=True)
+        (exp_path / "config.yml").write_text("dummy: true\n", encoding="utf-8")
+
+        result = _run_export_script(
+            repo_root,
+            exp_path,
+            ["--method", "orbit-frames", "--orbit-image-format", "webp"],
+        )
+        assert result.returncode != 0
+        assert "--orbit-image-format must be one of" in result.stdout + result.stderr
+
     def test_nerf_export_combines_mesh_and_orbit_frames(self, tmp_path: Path) -> None:
         """`orbit-frames` should compose with other requested NeRF export methods."""
         repo_root = Path(__file__).resolve().parents[1]

--- a/tests/test_export_script.py
+++ b/tests/test_export_script.py
@@ -600,6 +600,71 @@ class TestExportScriptNerfWorkflow:
         assert result.returncode == 0, result.stderr
         assert "--image-format png" in log_path.read_text(encoding="utf-8")
 
+    def test_orbit_format_change_does_not_render_into_a_stale_directory(
+        self, tmp_path: Path
+    ) -> None:
+        """Frames left from another format are not the output that was asked for."""
+        repo_root = Path(__file__).resolve().parents[1]
+        exp_path = tmp_path / "train" / "scene" / "nerfacto"
+        exp_path.mkdir(parents=True, exist_ok=True)
+        (exp_path / "config.yml").write_text("dummy: true\n", encoding="utf-8")
+        frames = exp_path / "orbit_frames"
+        frames.mkdir()
+        (frames / "00000.jpg").write_text("old", encoding="utf-8")
+
+        log_path = tmp_path / "stub.log"
+        bin_dir = tmp_path / "bin"
+        _make_stub_binaries(bin_dir, log_path)
+
+        env_overrides = {
+            "PATH": f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}",
+            "MINI_MESH_STUB_LOG": str(log_path),
+        }
+
+        result = _run_export_script(
+            repo_root,
+            exp_path,
+            ["--method", "orbit-frames", "--orbit-image-format", "png"],
+            env_overrides,
+        )
+        assert result.returncode == 0, result.stderr
+        assert "those frames are not png" in result.stdout
+        assert not log_path.exists() or "ns-render spiral" not in log_path.read_text(
+            encoding="utf-8"
+        )
+        assert (frames / "00000.jpg").exists()
+
+    def test_orbit_overwrite_clears_frames_of_the_previous_format(
+        self, tmp_path: Path
+    ) -> None:
+        """--overwrite re-renders, so the old frames go rather than mixing with the new."""
+        repo_root = Path(__file__).resolve().parents[1]
+        exp_path = tmp_path / "train" / "scene" / "nerfacto"
+        exp_path.mkdir(parents=True, exist_ok=True)
+        (exp_path / "config.yml").write_text("dummy: true\n", encoding="utf-8")
+        frames = exp_path / "orbit_frames"
+        frames.mkdir()
+        (frames / "00000.jpg").write_text("old", encoding="utf-8")
+
+        log_path = tmp_path / "stub.log"
+        bin_dir = tmp_path / "bin"
+        _make_stub_binaries(bin_dir, log_path)
+
+        env_overrides = {
+            "PATH": f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}",
+            "MINI_MESH_STUB_LOG": str(log_path),
+        }
+
+        result = _run_export_script(
+            repo_root,
+            exp_path,
+            ["--method", "orbit-frames", "--orbit-image-format", "png", "--overwrite"],
+            env_overrides,
+        )
+        assert result.returncode == 0, result.stderr
+        assert "--image-format png" in log_path.read_text(encoding="utf-8")
+        assert not (frames / "00000.jpg").exists()
+
     def test_orbit_image_format_rejects_unknown_value(self, tmp_path: Path) -> None:
         """An unsupported format fails loudly rather than reaching the renderer."""
         repo_root = Path(__file__).resolve().parents[1]

--- a/tests/test_webui.py
+++ b/tests/test_webui.py
@@ -926,6 +926,21 @@ class TestRunPipelineExportContext:
         )
         assert cmd == "scripts/run.sh /path/to/video.mp4 export --method poisson"
 
+    def test_export_orbit_image_format(self):
+        """Test export --orbit-image-format argument."""
+        from webui import run_pipeline
+
+        cmd = run_pipeline(
+            input_path="/path/to/video.mp4",
+            export_enable=True,
+            export_method="orbit-frames",
+            export_orbit_image_format="png",
+        )
+        assert cmd == (
+            "scripts/run.sh /path/to/video.mp4 export --method orbit-frames "
+            "--orbit-image-format png"
+        )
+
     def test_export_multiple_args(self):
         """Test export context with multiple arguments."""
         from webui import run_pipeline

--- a/tests/test_webui.py
+++ b/tests/test_webui.py
@@ -79,6 +79,16 @@ class TestCommandValidation:
         result = test_cmd(cmd, "scripts/run.sh")
         assert result is None
 
+    def test_orbit_image_format_passes_validation(self):
+        """The UI emits this flag, so the validator has to let it through."""
+        from webui import test_cmd
+
+        cmd = (
+            "scripts/run.sh /path/to/video.mp4 export --method orbit-frames "
+            "--orbit-image-format png"
+        )
+        assert test_cmd(cmd, "scripts/run.sh") is None
+
     def test_invalid_commands_caught_by_validation(self):
         """Test that manually constructed invalid commands are caught."""
         from webui import test_cmd

--- a/webui.py
+++ b/webui.py
@@ -302,6 +302,7 @@ def build_pipeline_argv(
     export_enable: bool = False,
     export_resolution: Optional[int] = None,
     export_method: Optional[str] = None,
+    export_orbit_image_format: Optional[str] = None,
     export_marching_cube_threshold: Optional[float] = None,
     export_num_pixels_per_side: Optional[int] = None,
     export_target_num_faces: Optional[int] = None,
@@ -392,6 +393,7 @@ def build_pipeline_argv(
         export_enable: Enable export context
         export_resolution: Export resolution
         export_method: Export method (poisson, tsdf, pointcloud, orbit-frames)
+        export_orbit_image_format: Orbit frame format (jpeg, png)
         export_marching_cube_threshold: Marching cubes isosurface threshold
         export_num_pixels_per_side: Texture resolution in pixels per side
         export_target_num_faces: Target number of faces for simplification
@@ -622,6 +624,8 @@ def build_pipeline_argv(
             cmd_parts.extend(["--resolution", str(export_resolution)])
         if export_method:
             cmd_parts.extend(["--method", export_method])
+        if export_orbit_image_format:
+            cmd_parts.extend(["--orbit-image-format", export_orbit_image_format])
         if export_marching_cube_threshold is not None:
             cmd_parts.extend(["--marching-cube-threshold", str(export_marching_cube_threshold)])
         if export_num_pixels_per_side is not None:
@@ -1354,6 +1358,13 @@ def create_ui() -> gr.Blocks:  # pragma: no cover
                         value="poisson",
                         info="NeRF mesh/point export, or orbit image frames for any model.",
                     )
+                    export_orbit_image_format = gr.Dropdown(
+                        label="Orbit Frame Format",
+                        choices=["jpeg", "png"],
+                        value="jpeg",
+                        info="PNG for frames scored against other renders; JPEG error grows "
+                        "with the effect being measured (docs/evaluation.md).",
+                    )
                     export_marching_cube_threshold = gr.Number(
                         label="Marching Cube Threshold",
                         value=None,
@@ -1550,6 +1561,7 @@ def create_ui() -> gr.Blocks:  # pragma: no cover
             train_overwrite_val,
             export_resolution_val,
             export_method_val,
+            export_orbit_image_format_val,
             export_marching_cube_threshold_val,
             export_num_pixels_per_side_val,
             export_target_num_faces_val,
@@ -1644,6 +1656,8 @@ def create_ui() -> gr.Blocks:  # pragma: no cover
                 train_vis_val = None
             if export_method_val == "poisson":
                 export_method_val = None
+            if export_orbit_image_format_val == "jpeg":
+                export_orbit_image_format_val = None
 
             # Build command
             has_extra_args = any(
@@ -1729,6 +1743,7 @@ def create_ui() -> gr.Blocks:  # pragma: no cover
                 [
                     export_resolution_val,
                     export_method_val,
+                    export_orbit_image_format_val,
                     export_marching_cube_threshold_val,
                     export_num_pixels_per_side_val,
                     export_target_num_faces_val,
@@ -1839,6 +1854,7 @@ def create_ui() -> gr.Blocks:  # pragma: no cover
                 export_enable=export_enable,
                 export_resolution=int(export_resolution_val) if export_resolution_val else None,
                 export_method=export_method_val or None,
+                export_orbit_image_format=export_orbit_image_format_val or None,
                 export_marching_cube_threshold=float(export_marching_cube_threshold_val)
                 if export_marching_cube_threshold_val is not None
                 else None,
@@ -2025,6 +2041,7 @@ def create_ui() -> gr.Blocks:  # pragma: no cover
             train_overwrite,
             export_resolution,
             export_method,
+            export_orbit_image_format,
             export_marching_cube_threshold,
             export_num_pixels_per_side,
             export_target_num_faces,

--- a/webui.py
+++ b/webui.py
@@ -209,6 +209,7 @@ def test_cmd(cmd: str, run_cmd: str) -> Optional[str]:
         "--px-per-uv-triangle",
         "--downscale-factor",
         "--method",
+        "--orbit-image-format",
         "--target-num-faces",
         "--bounding-box-min",
         "--bounding-box-max",


### PR DESCRIPTION
## Summary

`ns-eval` gives us PSNR, SSIM and LPIPS, and those three numbers have decided
every splat tuning question so far. Three subjective studies put all three near
0.5 Spearman correlation with human opinion scores on degraded Gaussian splats.
This doc collects what they measured, names which of our conclusions it weakens,
and proposes the cheapest way to check.

Refs: #34 (the doc records the evidence; the issue tracks the experiment)

## Changes

- `docs/evaluation.md`: correlation numbers from 3DGS-VBench, MUGSQA, 3DGS-QA
  and GS-QA; what each study degraded and why the four disagree; the effect on
  our cap_max, cleanup threshold, container and frame-count decisions; a
  three-step plan starting with DOVER on orbit renders already on disk
- `README.md`: link the new doc from the documentation list

## Type of Change

- [x] Documentation update

## Testing

- [ ] Ran `make check` (docs-only change, no code touched)

## Checklist

- [x] I have read the Contributing Guidelines
- [x] My code follows the existing style
- [x] I have updated documentation if needed
- [x] New flags are reflected in all entry points (no new flags)
