### PR TITLE
fix(export): match webui validation to export.sh and stop writing bad PLY headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,7 +329,7 @@ Gaussian is how a splat represents thin structure. The script also works on an e
 without re-exporting:
 
 ```bash
-scripts/clean_splat.py splat.ply --dry-run --clean-sor    # report what each stage would remove
+scripts/clean_splat.py splat.ply --dry-run --sor          # report what each stage would remove
 scripts/clean_splat.py splat.ply -o splat_clean.ply --opacity 0.1
 ```
 

--- a/scripts/clean_splat.py
+++ b/scripts/clean_splat.py
@@ -45,6 +45,20 @@ PLY_DTYPES = {
     "float64": "f8",
 }
 
+# Every width the reader accepts needs a way back out. Falling back to "float"
+# for an unmapped dtype writes a header that misdescribes the payload, and the
+# file is then silently misaligned rather than rejected.
+PLY_NAMES = {
+    "i1": "char",
+    "u1": "uchar",
+    "i2": "short",
+    "u2": "ushort",
+    "i4": "int",
+    "u4": "uint",
+    "f4": "float",
+    "f8": "double",
+}
+
 SCALE_FIELDS = ("scale_0", "scale_1", "scale_2")
 
 
@@ -121,14 +135,11 @@ def write_ply(path: Path, data: np.ndarray, names: list[str]) -> None:
         out[name] = data[name]
 
     header = ["ply", "format binary_little_endian 1.0", f"element vertex {len(out)}"]
-    reverse = {
-        value: key
-        for key, value in PLY_DTYPES.items()
-        if key in ("uchar", "int", "float", "double")
-    }
     for name in names:
         kind = out.dtype[name].str[1:]
-        header.append(f"property {reverse.get(kind, 'float')} {name}")
+        if kind not in PLY_NAMES:
+            raise PlyError(f"cannot write property {name!r} of type {kind!r}")
+        header.append(f"property {PLY_NAMES[kind]} {name}")
     header.append("end_header")
 
     path.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/test_clean_splat.py
+++ b/tests/test_clean_splat.py
@@ -139,3 +139,37 @@ def test_rejects_an_out_of_range_opacity(tmp_path: Path) -> None:
     clean_splat.write_ply(source, _splat(np.zeros(4, dtype=np.float32)), FIELDS)
 
     assert clean_splat.main([str(source), "--opacity", "1.5"]) == 2
+
+
+def test_round_trip_preserves_non_float_widths(tmp_path: Path) -> None:
+    """A PLY carrying integer properties has to survive rewriting unchanged.
+
+    The header is generated from the numpy dtype, so an unmapped width used to
+    be written out as "float" while the payload kept its original size, leaving
+    a file no reader can parse correctly.
+    """
+    names = ["x", "red", "material_id", "cluster"]
+    dtype = np.dtype([("x", "<f4"), ("red", "u1"), ("material_id", "<i2"), ("cluster", "<u4")])
+    data = np.zeros(4, dtype=dtype)
+    data["x"] = [0.5, 1.5, 2.5, 3.5]
+    data["red"] = [0, 127, 200, 255]
+    data["material_id"] = [-2, -1, 300, 32000]
+    data["cluster"] = [0, 1, 70000, 4000000000]
+    path = tmp_path / "typed.ply"
+
+    clean_splat.write_ply(path, data, names)
+    restored, restored_names = clean_splat.read_ply(path)
+
+    assert restored_names == names
+    for name in names:
+        assert restored.dtype[name] == dtype[name], name
+        assert np.array_equal(restored[name], data[name]), name
+
+
+def test_unwritable_property_type_is_reported(tmp_path: Path) -> None:
+    """A dtype with no PLY spelling raises instead of writing a wrong header."""
+    dtype = np.dtype([("x", "<f4"), ("stamp", "<i8")])
+    data = np.zeros(2, dtype=dtype)
+
+    with pytest.raises(clean_splat.PlyError, match="stamp"):
+        clean_splat.write_ply(tmp_path / "bad.ply", data, ["x", "stamp"])

--- a/tests/test_webui.py
+++ b/tests/test_webui.py
@@ -1837,6 +1837,32 @@ class TestArtifactDiscovery:
         assert find_mesh_artifacts(tmp_path)[:2] == [str(textured_mesh), str(mesh)]
 
 
+class TestExportContextArgs:
+    """The export allowlist has to match what scripts/export.sh parses."""
+
+    def test_cleanup_flags_belong_to_export(self):
+        """Cleanup flags are documented under export, so export must accept them."""
+        from webui import test_cmd
+
+        for arg in ("--no-clean", "--clean-opacity 0.1", "--clean-sor"):
+            cmd = f"scripts/run.sh /path/to/video.mp4 export {arg}"
+            assert test_cmd(cmd, "scripts/run.sh") is None, arg
+
+    def test_cleanup_flags_are_rejected_after_video(self):
+        """They were on the video allowlist by mistake; video must turn them down."""
+        from webui import test_cmd
+
+        cmd = "scripts/run.sh /path/to/video.mp4 video --no-clean"
+        assert test_cmd(cmd, "scripts/run.sh") == "Invalid video argument: --no-clean"
+
+    def test_obb_rotation_is_accepted(self):
+        """export.sh parses all three box flags; the allowlist was missing one."""
+        from webui import test_cmd
+
+        cmd = "scripts/run.sh /path/to/video.mp4 export --obb-rotation 0 0 0"
+        assert test_cmd(cmd, "scripts/run.sh") is None
+
+
 class TestCreateUI:
     """Smoke tests for the Gradio layout."""
 

--- a/webui.py
+++ b/webui.py
@@ -108,8 +108,6 @@ def test_cmd(cmd: str, run_cmd: str) -> Optional[str]:
         "--hdr",
         "--skip",
         "--overwrite",
-        "--no-clean",
-        "--clean-",
     ]
     video_pattern = r"video\s+(.*?)(?=\s+(sfm|process|train|export)\b|$)"
     video_match = re.search(video_pattern, cmd)
@@ -213,12 +211,15 @@ def test_cmd(cmd: str, run_cmd: str) -> Optional[str]:
         "--bounding-box-min",
         "--bounding-box-max",
         "--obb-center",
+        "--obb-rotation",
         "--obb-scale",
         "--mesh-only",
         "--texture-only",
         "--input-mesh-filename",
         "--skip",
         "--overwrite",
+        "--no-clean",
+        "--clean-",
     ]
     export_pattern = r"export\s+(.*?)$"
     export_match = re.search(export_pattern, cmd)


### PR DESCRIPTION
## Summary

Fixes three defects a Codex review found on #31 after it merged, plus one
adjacent flag that predates it.

Closes: #36

## Changes

- `webui.py`: move `--no-clean` and `--clean-` from the video allowlist to the
  export one, where `scripts/export.sh` actually parses them, and add the
  missing `--obb-rotation`
- `scripts/clean_splat.py`: map every scalar width the reader accepts back to a
  PLY type name, and raise on one that has no spelling instead of writing
  `float` over a payload of a different size
- `README.md`: the standalone `clean_splat.py` example called `--clean-sor`,
  which is the `export.sh` wrapper spelling; the script itself takes `--sor`
- Regression tests for all four. Each fails on the parent commit: the PLY one
  with `ValueError: buffer is smaller than requested size`

## Type of Change

- [x] Bug fix

## Testing

- [x] Ran `make check` (284 passed, 2 skipped)
- [ ] Tested with Docker
- [ ] Tested with manual installation
- [x] Added/updated tests

## Checklist

- [x] I have read the Contributing Guidelines
- [x] My code follows the existing style
- [x] I have updated documentation if needed
- [x] New flags are reflected in all entry points (no new flags; this aligns existing ones)
